### PR TITLE
경북대 BE_윤재용 3주차 과제 (0단계,1단계)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,23 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    runtimeOnly 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    // Database
+    runtimeOnly 'com.h2database:h2'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/gift/Application.java
+++ b/src/main/java/gift/Application.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class Application {
-    public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
 }

--- a/src/main/java/gift/core/annotaions/CharSetValidator.java
+++ b/src/main/java/gift/core/annotaions/CharSetValidator.java
@@ -1,0 +1,21 @@
+package gift.core.annotaions;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CharSetValidator implements ConstraintValidator<ValidCharset, String> {
+	private String pattern;
+
+	@Override
+	public void initialize(ValidCharset constraintAnnotation) {
+		this.pattern = constraintAnnotation.pattern();
+	}
+
+	@Override
+	public boolean isValid(String s, ConstraintValidatorContext context) {
+		if (s == null) {
+			return true;
+		}
+		return s.matches(pattern);
+	}
+}

--- a/src/main/java/gift/core/annotaions/NoKakao.java
+++ b/src/main/java/gift/core/annotaions/NoKakao.java
@@ -1,0 +1,23 @@
+package gift.core.annotaions;
+
+
+
+import gift.core.exception.ValidationMessage;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NoKakaoValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoKakao {
+	String message() default ValidationMessage.NO_KAKAO_MSG;
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}
+
+
+

--- a/src/main/java/gift/core/annotaions/NoKakaoValidator.java
+++ b/src/main/java/gift/core/annotaions/NoKakaoValidator.java
@@ -1,0 +1,18 @@
+package gift.core.annotaions;
+
+import gift.core.exception.ValidationMessage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NoKakaoValidator implements ConstraintValidator<NoKakao, String> {
+	@Override
+	public void initialize(NoKakao constraintAnnotation) {
+	}
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null) {
+			return true;
+		}
+		return !value.contains("카카오");
+	}
+}

--- a/src/main/java/gift/core/annotaions/ValidCharset.java
+++ b/src/main/java/gift/core/annotaions/ValidCharset.java
@@ -1,0 +1,25 @@
+package gift.core.annotaions;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import gift.core.exception.ValidationMessage;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = CharSetValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidCharset {
+	String message() default ValidationMessage.INVALID_CHARSET_MSG;
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+	String pattern() default "^[a-zA-Z0-9가-힣\\(\\)\\[\\]\\+\\-\\&\\/\\_]*$";
+}

--- a/src/main/java/gift/core/authorization/Role.java
+++ b/src/main/java/gift/core/authorization/Role.java
@@ -1,0 +1,5 @@
+package gift.core.authorization;
+
+public enum Role {
+	ADMIN, USER, ROLE
+}

--- a/src/main/java/gift/core/authorization/UserDetails.java
+++ b/src/main/java/gift/core/authorization/UserDetails.java
@@ -1,0 +1,29 @@
+package gift.core.authorization;
+
+import java.util.Set;
+
+import io.jsonwebtoken.Claims;
+import lombok.Getter;
+
+@Getter
+public class UserDetails {
+	private Set<Role> roles;
+	private Long userId;
+
+	private UserDetails(Set<Role> roles, Long userId) {
+		this.roles = roles;
+		this.userId = userId;
+	}
+
+	public static UserDetails of(Set<Role> roles, Long userId) {
+		return new UserDetails(roles, userId);
+	}
+
+	// TODO: 권한 부여가 완성 된 후, UserDetailService를 구현하여 UserDetails를 생성할 수 있도록 한다.
+	public static UserDetails from(Claims claims) {
+		return new UserDetails(
+			Set.of(Role.valueOf(claims.get("role", String.class))),
+			Long.parseLong(claims.getSubject())
+		);
+	}
+}

--- a/src/main/java/gift/core/authorization/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/gift/core/authorization/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,28 @@
+package gift.core.authorization.interceptor;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import gift.core.authorization.UserDetails;
+import gift.core.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Order(1)
+public class AuthorizationInterceptor implements HandlerInterceptor {
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		String rawToken = request.getHeader("Authorization");
+		request.setAttribute("USER", UserDetails.from(jwtProvider.getClaims(rawToken)));
+
+		//
+		// TODO: 이후 인터셉터에서 Controller의 필요한 권한과 유저의 권한을 비교하는 로직을 구현한다.
+		return true;
+	}
+}

--- a/src/main/java/gift/core/config/WebMvcConfig.java
+++ b/src/main/java/gift/core/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package gift.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import gift.core.authorization.interceptor.AuthorizationInterceptor;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+	private final AuthorizationInterceptor authorizationInterceptor;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(authorizationInterceptor)
+			.excludePathPatterns("/css/**", "/images/**", "/js/**")
+			.excludePathPatterns("/api/v1/user/signup")
+			.excludePathPatterns("/api/v1/user/login")
+			.excludePathPatterns("/user/login");
+	}
+}

--- a/src/main/java/gift/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/core/exception/GlobalExceptionHandler.java
@@ -1,0 +1,53 @@
+package gift.core.exception;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import gift.core.exception.product.DuplicateProductIdException;
+import gift.core.exception.product.ProductNotFoundException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	// ProblemDetail 중, 현재 반환 가능한 값만 설정하여 반환한다.
+	@ExceptionHandler(ProductNotFoundException.class)
+	public ProblemDetail handleProductNotFoundException(ProductNotFoundException ex, WebRequest request) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+		problemDetail.setTitle("Product Not Found");
+		return problemDetail;
+	}
+
+	@ExceptionHandler(DuplicateProductIdException.class)
+	public ProblemDetail handleDuplicateProductIdException(DuplicateProductIdException ex, WebRequest request) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+		problemDetail.setTitle("Duplicate Product ID");
+		return problemDetail;
+	}
+
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ProblemDetail handleValidationExceptions(MethodArgumentNotValidException ex, WebRequest request) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Validation failed");
+		problemDetail.setTitle("Validation Error");
+
+		Map<String, String> errors = new HashMap<>();
+		ex.getBindingResult().getAllErrors().forEach((error) -> {
+			String fieldName = ((FieldError) error).getField();
+			String errorMessage = error.getDefaultMessage();
+			errors.put(fieldName, errorMessage);
+		});
+		problemDetail.setProperty("errors", errors);
+
+		return problemDetail;
+	}
+	// TODO: JWTException 핸들러를 추가한다.
+}

--- a/src/main/java/gift/core/exception/ValidationMessage.java
+++ b/src/main/java/gift/core/exception/ValidationMessage.java
@@ -1,0 +1,21 @@
+package gift.core.exception;
+
+public enum ValidationMessage {
+	NO_KAKAO(ValidationMessage.NO_KAKAO_MSG),
+	INVALID_SIZE(ValidationMessage.INVALID_SIZE_MSG),
+	INVALID_CHARSET(ValidationMessage.INVALID_CHARSET_MSG);
+
+	public static final String NO_KAKAO_MSG = "cannot contain '카카오'";
+	public static final String INVALID_SIZE_MSG = "must be at most 15 characters long";
+	public static final String INVALID_CHARSET_MSG = "알파벳,한글,숫자,특수문자 ( ), [ ], +, -, &, /, _만 입력 가능합니다.";
+
+	private final String message;
+
+	ValidationMessage(String message) {
+		this.message = message;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/gift/core/exception/product/DuplicateProductIdException.java
+++ b/src/main/java/gift/core/exception/product/DuplicateProductIdException.java
@@ -1,0 +1,7 @@
+package gift.core.exception.product;
+
+public class DuplicateProductIdException extends RuntimeException {
+	public DuplicateProductIdException(String name) {
+		super("Product with ID " + name + " already exists");
+	}
+}

--- a/src/main/java/gift/core/exception/product/ProductNotFoundException.java
+++ b/src/main/java/gift/core/exception/product/ProductNotFoundException.java
@@ -1,0 +1,7 @@
+package gift.core.exception.product;
+
+public class ProductNotFoundException extends RuntimeException {
+	public ProductNotFoundException(Long id) {
+		super("Product with ID " + id + " not found");
+	}
+}

--- a/src/main/java/gift/core/jwt/JwtProvider.java
+++ b/src/main/java/gift/core/jwt/JwtProvider.java
@@ -1,0 +1,72 @@
+package gift.core.jwt;
+
+import java.security.Key;
+import java.util.Date;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class JwtProvider {
+	private final String secret = "gift-secret-key-yooonwodyd-2024-07-05-2024-12-31";
+	private static final String HEADER_PREFIX = "Bearer ";
+	private static final long TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 7; // 7일
+	private Key secretKey;
+
+	// SecretKey 초기화
+	@PostConstruct
+	public void init() {
+		secretKey = new SecretKeySpec(secret.getBytes(), SignatureAlgorithm.HS256.getJcaName());
+	}
+
+	// And로 목적
+	public Claims getClaims(String rawToken) {
+		var token = parseHeader(rawToken);
+		return extractClaims(token);
+	}
+
+	public String parseHeader(String header) {
+		if (header == null || header.isEmpty()) {
+			throw new IllegalArgumentException("Authorization 헤더가 없습니다.");
+		} else if (!header.startsWith(HEADER_PREFIX)) {
+			throw new IllegalArgumentException("Authorization 올바르지 않습니다. Bearer로 시작해야합니다.");
+		} else if (header.split(" ").length != 2) {
+			throw new IllegalArgumentException("Authorization 올바르지 않습니다.");
+		}
+
+		return header.split(" ")[1];
+	}
+
+	// 토큰 생성, ROLE을 담아서 반환
+	public String generateToken(String userId, String role) {
+		Date now = new Date();
+		Date expiryDate = new Date(now.getTime() + TOKEN_VALIDITY);
+
+		return Jwts.builder()
+			.setSubject(userId)
+			.claim("role", role)
+			.setIssuedAt(now)
+			.setExpiration(expiryDate)
+			.signWith(secretKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	private Claims extractClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			throw new JwtException("토큰이 만료되었습니다.");
+		}
+	}
+}

--- a/src/main/java/gift/feat/admin/AdminController.java
+++ b/src/main/java/gift/feat/admin/AdminController.java
@@ -1,0 +1,43 @@
+package gift.feat.admin;
+
+import java.util.List;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import gift.feat.product.dto.ProductResponseDto;
+import gift.feat.product.service.ProductService;
+
+import gift.feat.user.repository.UserJpaRepository;
+import gift.feat.wishList.WishProductJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminController {
+	private final ProductService productService;
+	private final WishProductJpaRepository wishListRepository;
+	private final UserJpaRepository userRepository;
+
+	@GetMapping("/admin/product")
+	public String viewProducts(Model model) {
+		List<ProductResponseDto> products = productService.getAllProducts().stream()
+			.map(ProductResponseDto::from)
+			.toList();
+		model.addAttribute("products", products);
+		return "admin/productPage";
+	}
+
+
+	@GetMapping("/admin/user/wishlist/{userId}")
+	public String viewWishList(Model model,@PathVariable Long userId) {
+		List<ProductResponseDto> products = wishListRepository.findByUserId(userId).stream()
+			.map(wishProduct -> ProductResponseDto.from(wishProduct.getProduct()))
+			.toList();
+		model.addAttribute("products", products);
+		return "admin/wishListPage";
+	}
+
+}

--- a/src/main/java/gift/feat/product/contoller/ProductRestController.java
+++ b/src/main/java/gift/feat/product/contoller/ProductRestController.java
@@ -1,0 +1,48 @@
+package gift.feat.product.contoller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import gift.feat.product.domain.Product;
+import gift.feat.product.dto.ProductRequestDto;
+import gift.feat.product.dto.ProductResponseDto;
+import gift.feat.product.service.ProductService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductRestController {
+
+	private final ProductService productService;
+
+
+	@PostMapping("/api/v1/product")
+	@ResponseBody
+	public ResponseEntity<Long> registerProduct(@RequestBody @Valid ProductRequestDto productRequestDto) {
+		// 등록된 상품의 ID를 반환.
+		return ResponseEntity.ok(productService.saveProduct(productRequestDto));
+	}
+
+	@GetMapping("/api/v1/product/{id}")
+	@ResponseBody
+	public ResponseEntity<ProductResponseDto> getProduct(@PathVariable Long id) {
+		Product product = productService.getProductById(id);
+		return ResponseEntity.ok(ProductResponseDto.from(product));
+	}
+
+	@PutMapping("/api/v1/product/{id}")
+	@ResponseBody
+	public ResponseEntity<?> updateProduct(@PathVariable Long id, @RequestBody @Valid ProductRequestDto productRequestDto) {
+
+		// 수정된 상품 ID를 같이 반환한다.
+		return ResponseEntity.ok(productService.updateProduct(id, productRequestDto));
+	}
+
+	@DeleteMapping("/api/v1/product/{id}")
+	@ResponseBody
+	public ResponseEntity<?> deleteProduct(@PathVariable Long id) {
+		productService.deleteProduct(id);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/gift/feat/product/domain/Product.java
+++ b/src/main/java/gift/feat/product/domain/Product.java
@@ -1,0 +1,81 @@
+package gift.feat.product.domain;
+
+import java.util.Objects;
+
+import gift.feat.product.dto.ProductResponseDto;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Product {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+	private String name;
+	private Long price;
+	private String imageUrl;
+
+	protected Product() {
+
+	}
+	private Product(String name, Long price, String imageUrl) {
+		this.name = name;
+		this.price = price;
+		this.imageUrl = imageUrl;
+	}
+
+	public static Product of(String name, Long price, String imageUrl) {
+		return new Product(name, price, imageUrl);
+	}
+
+	public static Product from(ProductResponseDto productResponseDto) {
+		return new Product( productResponseDto.name(), productResponseDto.price(),
+			productResponseDto.imageUrl());
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Long getPrice() {
+		return price;
+	}
+
+	public void setPrice(Long price) {
+		this.price = price;
+	}
+
+	public String getImageUrl() {
+		return imageUrl;
+	}
+
+	public void setImageUrl(String imageUrl) {
+		this.imageUrl = imageUrl;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof Product product))
+			return false;
+		return Objects.equals(id, product.id) && Objects.equals(name, product.name)
+			&& Objects.equals(price, product.price) && Objects.equals(imageUrl, product.imageUrl);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, name, price, imageUrl);
+	}
+}

--- a/src/main/java/gift/feat/product/dto/ProductRequestDto.java
+++ b/src/main/java/gift/feat/product/dto/ProductRequestDto.java
@@ -1,0 +1,21 @@
+package gift.feat.product.dto;
+
+import gift.core.annotaions.NoKakao;
+import gift.core.annotaions.ValidCharset;
+import gift.core.exception.ValidationMessage;
+import gift.feat.product.domain.Product;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ProductRequestDto(
+	@Size(max = 15, message = ValidationMessage.INVALID_SIZE_MSG)
+	@ValidCharset
+	@NoKakao
+	String name,
+	Long price,
+	String imageUrl
+) {
+	public Product toEntity() {
+		return Product.of(name, price, imageUrl);
+	}
+}

--- a/src/main/java/gift/feat/product/dto/ProductResponseDto.java
+++ b/src/main/java/gift/feat/product/dto/ProductResponseDto.java
@@ -1,0 +1,17 @@
+package gift.feat.product.dto;
+
+import gift.feat.product.domain.Product;
+
+public record ProductResponseDto(
+	String name,
+	Long price,
+	String imageUrl
+) {
+	static public ProductResponseDto from(Product product) {
+		return new ProductResponseDto(
+			product.getName(),
+			product.getPrice(),
+			product.getImageUrl()
+		);
+	}
+}

--- a/src/main/java/gift/feat/product/dto/UserResponseDto.java
+++ b/src/main/java/gift/feat/product/dto/UserResponseDto.java
@@ -1,0 +1,23 @@
+package gift.feat.product.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+import gift.feat.user.User;
+
+public record UserResponseDto(
+	// id,email,password,roll,wishList
+	Long id,
+	String email,
+	String password,
+	String role
+) {
+	static public UserResponseDto from(User user) {
+		return new UserResponseDto(
+			user.getId(),
+			user.getEmail(),
+			user.getPassword(),
+			user.getRole()
+		);
+	}
+}

--- a/src/main/java/gift/feat/product/repository/ProductJpaRepository.java
+++ b/src/main/java/gift/feat/product/repository/ProductJpaRepository.java
@@ -1,0 +1,11 @@
+package gift.feat.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import gift.feat.product.domain.Product;
+
+@Repository
+public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+	Product findByName(String name);
+}

--- a/src/main/java/gift/feat/product/service/ProductService.java
+++ b/src/main/java/gift/feat/product/service/ProductService.java
@@ -1,0 +1,55 @@
+package gift.feat.product.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gift.feat.product.domain.Product;
+import gift.feat.product.dto.ProductRequestDto;
+import gift.core.exception.product.DuplicateProductIdException;
+import gift.core.exception.product.ProductNotFoundException;
+import gift.feat.product.repository.ProductJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+	private final ProductJpaRepository productRepository;
+
+	@Transactional
+	public Long saveProduct(ProductRequestDto productRequestDto) {
+		if (productRepository.findByName(productRequestDto.name()) != null) {
+			throw new DuplicateProductIdException(productRequestDto.name());
+		}
+		return productRepository.save(productRequestDto.toEntity()).getId();
+	}
+
+	@Transactional(readOnly = true)
+	public Product getProductById(Long id) {
+		return productRepository.findById(id)
+			.orElseThrow(() -> new ProductNotFoundException(id));
+	}
+
+	@Transactional(readOnly = true)
+	public List<Product> getAllProducts() {
+		return productRepository.findAll();
+	}
+
+	@Transactional
+	public Long updateProduct(Long id, ProductRequestDto productRequestDto) {
+		Product existingProduct = productRepository.findById(id)
+			.orElseThrow(() -> new ProductNotFoundException(id));
+		existingProduct.setName(productRequestDto.name());
+		existingProduct.setPrice(productRequestDto.price());
+		existingProduct.setImageUrl(productRequestDto.imageUrl());
+		return productRepository.save(existingProduct).getId();
+	}
+
+	public void deleteProduct(Long id) {
+		Product existingProduct = productRepository.findById(id)
+			.orElseThrow(() -> new ProductNotFoundException(id));
+		productRepository.deleteById(id);
+	}
+}

--- a/src/main/java/gift/feat/user/User.java
+++ b/src/main/java/gift/feat/user/User.java
@@ -1,0 +1,65 @@
+package gift.feat.user;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import gift.feat.product.domain.Product;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+
+	@Column(nullable = false)
+	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	private String role;
+
+	public User() {
+	}
+
+	private User(String email, String password, String role) {
+		this.email = email;
+		this.password = password;
+		this.role = role;
+	}
+
+	public static User of( String email, String password, String role) {
+		return new User(email, password, role);
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public String getRole() {
+		return role;
+	}
+}

--- a/src/main/java/gift/feat/user/controller/UserController.java
+++ b/src/main/java/gift/feat/user/controller/UserController.java
@@ -1,0 +1,14 @@
+package gift.feat.user.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/user")
+public class UserController {
+	@GetMapping("/login")
+	public String login() {
+		return "user/login";
+	}
+}

--- a/src/main/java/gift/feat/user/controller/UserRestController.java
+++ b/src/main/java/gift/feat/user/controller/UserRestController.java
@@ -1,0 +1,30 @@
+package gift.feat.user.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+import gift.feat.user.dto.LoginRequestDto;
+import gift.feat.user.dto.SignupRequestDto;
+import gift.feat.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserRestController {
+	private final UserService userService;
+
+	// email과 패스워드를 입력하면, 해당 유저의 정보를 JWT access token으로 반환
+	@PostMapping("/login")
+	public String login(@RequestBody LoginRequestDto loginRequestDto) {
+		return userService.checkEmailAndPassword(loginRequestDto.email(), loginRequestDto.password());
+	}
+
+	@PostMapping("/signup")
+	public void signup(@RequestBody SignupRequestDto signupRequestDto) {
+		userService.registerUser(signupRequestDto.toEntity());
+	}
+}

--- a/src/main/java/gift/feat/user/dto/LoginRequestDto.java
+++ b/src/main/java/gift/feat/user/dto/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package gift.feat.user.dto;
+
+public record LoginRequestDto(
+	Long id,
+	String email,
+	String password,
+	String role
+) {
+}

--- a/src/main/java/gift/feat/user/dto/SignupRequestDto.java
+++ b/src/main/java/gift/feat/user/dto/SignupRequestDto.java
@@ -1,0 +1,14 @@
+package gift.feat.user.dto;
+
+import gift.feat.user.User;
+
+public record SignupRequestDto(
+	String email,
+	String password,
+	String role
+) {
+	// toEntity() 메소드를 추가
+	public User toEntity() {
+		return User.of(email, password, role);
+	}
+}

--- a/src/main/java/gift/feat/user/repository/UserJpaRepository.java
+++ b/src/main/java/gift/feat/user/repository/UserJpaRepository.java
@@ -1,0 +1,11 @@
+package gift.feat.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import gift.feat.user.User;
+
+@Repository
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+	User findByEmail(String email);
+}

--- a/src/main/java/gift/feat/user/service/UserService.java
+++ b/src/main/java/gift/feat/user/service/UserService.java
@@ -1,0 +1,35 @@
+package gift.feat.user.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import gift.core.jwt.JwtProvider;
+import gift.feat.user.User;
+import gift.feat.user.repository.UserJpaRepository;
+
+@Service
+public class UserService {
+	private final UserJpaRepository userJpaRepository;
+	private final JwtProvider jwtProvider;
+
+	public String checkEmailAndPassword(String email, String password) {
+		User user = userJpaRepository.findByEmail(email);
+		if (user == null) {
+			return null; // TODO: 예외 처리
+		}
+		if (!user.getPassword().equals(password)) {
+			return null; // TODO: 예외 처리
+		}
+		return jwtProvider.generateToken(user.getId().toString(), user.getRole());
+	}
+
+	public void registerUser(User user) {
+		userJpaRepository.save(user);
+	}
+
+	@Autowired
+	public UserService(UserJpaRepository userJpaRepository, JwtProvider jwtProvider) {
+		this.userJpaRepository = userJpaRepository;
+		this.jwtProvider = jwtProvider;
+	}
+}

--- a/src/main/java/gift/feat/wishList/WishProduct.java
+++ b/src/main/java/gift/feat/wishList/WishProduct.java
@@ -1,0 +1,60 @@
+package gift.feat.wishList;
+
+
+import gift.feat.product.domain.Product;
+import gift.feat.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Entity
+public class WishProduct {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "product_id")
+	private Product product;
+
+	protected WishProduct() {
+	}
+
+	private WishProduct(User user, Product product) {
+		this.user = user;
+		this.product = product;
+	}
+	public static WishProduct of(User user, Product product) {
+		return new WishProduct(user, product);
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public Product getProduct() {
+		return product;
+	}
+
+}
+

--- a/src/main/java/gift/feat/wishList/WishProductController.java
+++ b/src/main/java/gift/feat/wishList/WishProductController.java
@@ -1,0 +1,38 @@
+package gift.feat.wishList;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import gift.core.authorization.UserDetails;
+import gift.feat.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/wishlist")
+@RequiredArgsConstructor
+public class WishProductController {
+	private final WishProductJpaRepository wishListRepository;
+	private final WishProductService wishProductService;
+	private final ProductService productService;
+
+	// 위시리스트에 상품 추가
+	@PostMapping("")
+	public void addWishList(@RequestAttribute("USER") UserDetails userDetails, @RequestParam Long productId) {
+		wishProductService.save(productId, userDetails.getUserId());
+	}
+
+	//로그인한 유저의 위시리스트 조회
+	@GetMapping("")
+	public List<WishProductResponseDto> getWishList(@RequestAttribute("USER") UserDetails userDetails) {
+		List<WishProduct> wishList = wishProductService.findByUserId(userDetails.getUserId());
+		return wishList.stream()
+			.map(WishProductResponseDto::from)
+			.toList();
+	}
+}

--- a/src/main/java/gift/feat/wishList/WishProductJpaRepository.java
+++ b/src/main/java/gift/feat/wishList/WishProductJpaRepository.java
@@ -1,0 +1,12 @@
+package gift.feat.wishList;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WishProductJpaRepository extends JpaRepository<WishProduct, Long> {
+	WishProduct findByProductIdAndUserId(Long productId, Long userId);
+	List<WishProduct> findByUserId(Long userId);
+}

--- a/src/main/java/gift/feat/wishList/WishProductResponseDto.java
+++ b/src/main/java/gift/feat/wishList/WishProductResponseDto.java
@@ -1,0 +1,12 @@
+package gift.feat.wishList;
+
+import gift.feat.product.domain.Product;
+import gift.feat.product.dto.ProductResponseDto;
+
+public record WishProductResponseDto(
+	ProductResponseDto product
+) {
+	static public WishProductResponseDto from(WishProduct wishProduct) {
+		return new WishProductResponseDto(ProductResponseDto.from(wishProduct.getProduct()));
+	}
+}

--- a/src/main/java/gift/feat/wishList/WishProductService.java
+++ b/src/main/java/gift/feat/wishList/WishProductService.java
@@ -1,0 +1,43 @@
+package gift.feat.wishList;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import gift.feat.product.domain.Product;
+import gift.feat.product.repository.ProductJpaRepository;
+import gift.feat.user.User;
+import gift.feat.user.repository.UserJpaRepository;
+
+@Service
+public class WishProductService {
+	private final WishProductJpaRepository wishProductJpaRepository;
+	private final ProductJpaRepository productJpaRepository;
+	private final UserJpaRepository userJpaRepository;
+
+
+	public List<WishProduct> findByUserId(Long userId) {
+		return wishProductJpaRepository.findByUserId(userId);
+	}
+
+	public WishProduct save(Long productId, Long userId) {
+		User user = userJpaRepository.findById(userId).orElseThrow();
+		Product product = productJpaRepository.findById(productId).orElseThrow();
+		WishProduct wishProduct = WishProduct.of(user, product);
+		return wishProductJpaRepository.save(wishProduct);
+	}
+
+	public void delete(WishProduct wishProduct) {
+		wishProductJpaRepository.delete(wishProduct);
+	}
+
+	@Autowired
+	public WishProductService(WishProductJpaRepository wishProductJpaRepository,
+		ProductJpaRepository productJpaRepository,
+		UserJpaRepository userJpaRepository) {
+		this.wishProductJpaRepository = wishProductJpaRepository;
+		this.productJpaRepository = productJpaRepository;
+		this.userJpaRepository = userJpaRepository;
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=spring-gift

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug

--- a/src/main/resources/templates/admin/productPage.html
+++ b/src/main/resources/templates/admin/productPage.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Product Management</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100 text-gray-900">
+<div class="container mx-auto p-4">
+    <h1 class="text-3xl font-bold mb-4">Product Management</h1>
+    <h2 class="text-2xl font-semibold mb-2">Products</h2>
+    <table class="min-w-full bg-white">
+        <thead class="bg-gray-800 text-white">
+        <tr>
+            <th class="w-1/4 py-2">ID</th>
+            <th class="w-1/4 py-2">Name</th>
+            <th class="w-1/4 py-2">Price</th>
+            <th class="w-1/4 py-2">Image URL</th>
+        </tr>
+        </thead>
+        <tbody id="productTable" class="text-gray-700">
+        <tr th:each="product : ${products}">
+            <td class="w-1/4 py-2 px-4 border-b" th:text="${product.id}"></td>
+            <td class="w-1/4 py-2 px-4 border-b" th:text="${product.name}"></td>
+            <td class="w-1/4 py-2 px-4 border-b" th:text="${product.price}"></td>
+            <td class="w-1/4 py-2 px-4 border-b" th:text="${product.imageUrl}"></td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">Manage Product</h2>
+    <form id="productForm" class="bg-white p-4 rounded shadow-md">
+        <div class="mb-4">
+            <label for="id" class="block text-sm font-medium text-gray-700">ID:</label>
+            <input type="text" id="id" name="id" class="mt-1 p-2 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+        </div>
+        <div class="mb-4">
+            <label for="name" class="block text-sm font-medium text-gray-700">Name:</label>
+            <input type="text" id="name" name="name" class="mt-1 p-2 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+        </div>
+        <div class="mb-4">
+            <label for="price" class="block text-sm font-medium text-gray-700">Price:</label>
+            <input type="number" id="price" name="price" class="mt-1 p-2 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+        </div>
+        <div class="mb-4">
+            <label for="imageUrl" class="block text-sm font-medium text-gray-700">Image URL:</label>
+            <input type="text" id="imageUrl" name="imageUrl" class="mt-1 p-2 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+        </div>
+        <div class="flex space-x-4">
+            <button type="button" onclick="registerProduct()" class="bg-green-500 text-white py-2 px-4 rounded hover:bg-green-700">Register</button>
+            <button type="button" onclick="updateProduct()" class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700">Update</button>
+            <button type="button" onclick="deleteProduct()" class="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-700">Delete</button>
+        </div>
+    </form>
+</div>
+
+<script>
+    async function registerProduct() {
+        const id = document.getElementById('id').value;
+        const name = document.getElementById('name').value;
+        const price = document.getElementById('price').value;
+        const imageUrl = document.getElementById('imageUrl').value;
+
+        const product = { id: parseInt(id), name, price: parseFloat(price), imageUrl };
+
+        try {
+            const response = await fetch('/api/v1/product', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(product)
+            });
+
+            if (response.ok) {
+                alert('Product registered successfully');
+                window.location.reload();
+            } else {
+                alert('Failed to register product');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            alert('An error occurred');
+        }
+    }
+
+    async function updateProduct() {
+        const id = document.getElementById('id').value;
+        const name = document.getElementById('name').value;
+        const price = document.getElementById('price').value;
+        const imageUrl = document.getElementById('imageUrl').value;
+
+        const product = { id: parseInt(id), name, price: parseFloat(price), imageUrl };
+
+        try {
+            const response = await fetch(`/api/v1/product/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(product)
+            });
+
+            if (response.ok) {
+                alert('Product updated successfully');
+                window.location.reload();
+            } else {
+                alert('Failed to update product');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            alert('An error occurred');
+        }
+    }
+
+    async function deleteProduct() {
+        const id = document.getElementById('id').value;
+
+        try {
+            const response = await fetch(`/api/v1/product/${id}`, {
+                method: 'DELETE'
+            });
+
+            if (response.ok) {
+                alert('Product deleted successfully');
+                window.location.reload();
+            } else {
+                alert('Failed to delete product');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            alert('An error occurred');
+        }
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/wishListPage.html
+++ b/src/main/resources/templates/admin/wishListPage.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>User Wish List</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-5">
+    <h2>User Wish List</h2>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Price</th>
+            <th>Image</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="product : ${products}">
+            <td th:text="${product.id}"></td>
+            <td th:text="${product.name}"></td>
+            <td th:text="${product.price}"></td>
+            <td><img th:src="${product.imageUrl}" alt="Product Image" style="width:100px;height:auto;"/></td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>User Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<form id="loginForm">
+    <label for="email">Email:</label>
+    <input type="email" id="loginEmail" name="email" required>
+    <br>
+    <label for="password">Password:</label>
+    <input type="password" id="loginPassword" name="password" required>
+    <br>
+    <button type="button" onclick="login()">Login</button>
+</form>
+
+<h1>Signup</h1>
+<form id="signupForm">
+    <label for="email">Email:</label>
+    <input type="email" id="signupEmail" name="email" required>
+    <br>
+    <label for="password">Password:</label>
+    <input type="password" id="signupPassword" name="password" required>
+    <br>
+    <label for="role">Role:</label>
+    <input type="text" id="signupRole" name="role" required>
+    <br>
+    <button type="button" onclick="signup()">Signup</button>
+</form>
+
+<script>
+    function login() {
+        var email = document.getElementById('loginEmail').value;
+        var password = document.getElementById('loginPassword').value;
+
+        var data = {
+            email: email,
+            password: password
+        };
+
+        fetch('/api/v1/user/login', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Login failed');
+                }
+                return response.text();
+            })
+            .then(token => {
+                document.cookie = `token=${token}; path=/`;
+                alert('Login successful');
+                fetchAdminUserPage(token);
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Login failed');
+            });
+    }
+
+    function signup() {
+        var email = document.getElementById('signupEmail').value;
+        var password = document.getElementById('signupPassword').value;
+        var role = document.getElementById('signupRole').value;
+
+        var data = {
+            email: email,
+            password: password,
+            role: role
+        };
+
+        fetch('/api/v1/user/signup', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Signup failed');
+                }
+                return response.text();
+            })
+            .then(() => {
+                alert('Signup successful. Please login.');
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Signup failed');
+            });
+    }
+
+    function fetchAdminUserPage(token) {
+        fetch('/admin/user', {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${token}`
+            }
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Failed to fetch admin user page');
+                }
+                window.location.href = "/admin/user";
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Failed to fetch admin user page');
+            });
+    }
+</script>
+</body>
+</html>

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -1,0 +1,4 @@
+package gift.controller;
+
+public class ProductControllerTest {
+}

--- a/src/test/java/gift/dto/ProductRequestDtoTest.java
+++ b/src/test/java/gift/dto/ProductRequestDtoTest.java
@@ -1,0 +1,83 @@
+package gift.dto;
+
+import gift.core.exception.ValidationMessage;
+import gift.feat.product.dto.ProductRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProductRequestDtoTest {
+
+	private Validator validator;
+
+	@BeforeEach
+	public void setUp() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+
+	@Test
+	@DisplayName("'카카오'를 포함하지 않는 정상적인 '한글' 상품명을 가진 ProductRequestDto를 생성한다.")
+	public void testValidProductRequestDtoWithKoreanName() {
+		ProductRequestDto product = new ProductRequestDto( "초콜릿", 1000L, "http://example.com/image.png");
+
+		Set<ConstraintViolation<ProductRequestDto>> violations = validator.validate(product);
+		assertTrue(violations.isEmpty());
+	}
+
+	@Test
+	@DisplayName("'카카오'를 포함하지 않는 정상적인 상품명을 가진 ProductRequestDto를 생성한다.")
+	public void testValidProductRequestDto() {
+		ProductRequestDto product = new ProductRequestDto("chocolate", 1000L, "http://example.com/image.png");
+
+		Set<ConstraintViolation<ProductRequestDto>> violations = validator.validate(product);
+		assertTrue(violations.isEmpty());
+	}
+
+	@Test
+	@DisplayName("상품명에 '카카오'를 포함하면 ProductRequestDto를 생성할 수 없다.")
+	public void testProductNameContainsKakao() {
+		ProductRequestDto product = new ProductRequestDto("카카오초콜릿", 1000L, "http://example.com/image.png");
+
+		Set<ConstraintViolation<ProductRequestDto>> violations = validator.validate(product);
+
+		assertEquals(1, violations.size());
+		// List<String> violationMessages = violations.stream()
+		// 	.map(ConstraintViolation::getMessage)
+		// 	.collect(Collectors.toList());
+		// System.out.println(violationMessages);
+		assertEquals(ValidationMessage.NO_KAKAO_MSG, violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("상품명에 유효하지 않은 특수문자를 포함하면 ProductRequestDto를 생성할 수 없다.")
+	public void testProductNameWithInvalidCharacters() {
+		ProductRequestDto product = new ProductRequestDto( "Chocolate@!", 1000L, "http://example.com/image.png");
+
+		Set<ConstraintViolation<ProductRequestDto>> violations = validator.validate(product);
+		assertEquals(ValidationMessage.INVALID_CHARSET_MSG, violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("상품명이 15자를 초과하면 ProductRequestDto를 생성할 수 없다.")
+	public void testProductNameTooLong() {
+		ProductRequestDto product = new ProductRequestDto("VeryLongProductNameThatExceedsTheLimit", 1000L, "http://example.com/image.png");
+
+		Set<ConstraintViolation<ProductRequestDto>> violations = validator.validate(product);
+		assertFalse(violations.isEmpty());
+		assertEquals(1, violations.size());
+		assertEquals(ValidationMessage.INVALID_SIZE_MSG, violations.iterator().next().getMessage());
+	}
+}

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -1,0 +1,51 @@
+package gift.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import gift.feat.product.domain.Product;
+import gift.feat.product.repository.ProductJpaRepository;
+
+@DataJpaTest
+public class ProductRepositoryTest {
+	@Autowired
+	private ProductJpaRepository productRepository;
+
+	@Test
+	@DisplayName("상품 저장한뒤 반환 값이 일치하는 지 확인")
+	void save() {
+		// given
+		String name = "상품1";
+		Product product = Product.of(name, 1000L, "image1");
+		productRepository.save(product);
+
+		// when
+		Product savedProduct = productRepository.findByName(name);
+
+		// then
+		assertThat(savedProduct.getName()).isEqualTo(name);
+		assertThat(savedProduct.getPrice()).isEqualTo(1000);
+		assertThat(savedProduct.getImageUrl()).isEqualTo("image1");
+	}
+
+	@Test
+	@DisplayName("저장된 상품을 이름으로 성공적으로 조회한다.")
+	void findByName() {
+		// given
+		String name = "상품1";
+		Product product = Product.of(name, 1000L, "image1");
+		productRepository.save(product);
+
+		// when
+		Product savedProduct = productRepository.findByName(name);
+
+		// then
+		assertThat(savedProduct.getName()).isEqualTo(name);
+		assertThat(savedProduct.getPrice()).isEqualTo(1000);
+		assertThat(savedProduct.getImageUrl()).isEqualTo("image1");
+	}
+}

--- a/src/test/java/gift/repository/UserRepositoryTest.java
+++ b/src/test/java/gift/repository/UserRepositoryTest.java
@@ -1,0 +1,4 @@
+package gift.repository;
+
+public class UserRepositoryTest {
+}

--- a/src/test/java/gift/repository/WishProductRepositoryTest.java
+++ b/src/test/java/gift/repository/WishProductRepositoryTest.java
@@ -1,0 +1,4 @@
+package gift.repository;
+
+public class WishProductRepositoryTest {
+}


### PR DESCRIPTION
### 세부 구현 내용
2주차 멘토님의 피드백에 따라, 다음을 수정했습니다.
- 패스워드를 검증하는 로직 추가
- 테스트시 문자열로 비교를 별도의 Enum으로 변경

### 요구사항에 따라 다음을 수정했습니다.
- Controller에서 저장 성공시, id를 반환하도록 변경
- 기존에 적용했던 롬복 일부 제거
- JPA 사용에 따라  객체와 테이블을 매핑

### 궁금한 점
인터셉터를 사용한 로그인을 고도화 하는 과정에서, 다음과 같은 의문이 들었습니다.
```java
	@Override
	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
		String rawToken = request.getHeader("Authorization");
		request.setAttribute("USER", UserDetails.from(jwtProvider.getClaims(rawToken)));

		//
		// TODO: 이후 인터셉터에서 Controller의 필요한 권한과 유저의 권한을 비교하는 로직을 구현한다.
		return true;
	}
```
해당 로직에서는 jwt 토큰의 유저가 데이터베이스에 실제로 존재하는지를 체크하지 않습니다.
이를 확인하기 위해선 userDetailService와 같은 서비스 로직을 통해 데이터베이스의 유저와 비교하는 작업이 필요하다고 생각했습니다.
다만 이 경우 Interceptor -> service -> repository -> controller 순으로 접근하게 되면서, 레이어를 구별한 의미가 퇴색되지 않나 싶습니다.
이에 대해 멘토님의 의견을 여쭙고싶습니다!