### PR TITLE
강원대 BE_이강욱_3주차 과제(3단계)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,10 @@
 ## step2 - 엔티티 모델링
 
 1. 엔티티 연관 관계 설정
-   - [ ] `Wish` 엔티티가 `User`, `Product` 참조하도록 함
-   - [ ] `user_id`, `product_id`를 FK로 가지도록 설정
+   - [x] `Wish` 엔티티가 `User`, `Product` 참조하도록 함
+   - [x] `user_id`, `product_id`를 FK로 가지도록 설정
+
+## step3 - 페이지네이션
+   - [ ] `Product` 에 대해 페이지네이션 구현
+   - [ ] `Wish` 에 대해 페이지네이션 구현
+   

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'com.h2database:h2'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -1,13 +1,11 @@
 package gift.controller;
 
+import gift.dto.ProductPageResponseDto;
 import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,10 +36,9 @@ public class ProductController {
 
     @GetMapping
     @Operation(summary = "모든 상품 조회", description = "모든 상품을 조회합니다.")
-    public ResponseEntity<Page<ProductResponseDto>> getAllProducts(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<ProductResponseDto> productDTOs = productService.getAllProducts(pageable);
-        return new ResponseEntity<>(productDTOs, HttpStatus.OK);
+    public ResponseEntity<ProductPageResponseDto> getAllProducts(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        ProductPageResponseDto responseDto = productService.getAllProducts(page, size);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -5,11 +5,12 @@ import gift.dto.ProductResponseDto;
 import gift.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/products")
@@ -37,8 +38,9 @@ public class ProductController {
 
     @GetMapping
     @Operation(summary = "모든 상품 조회", description = "모든 상품을 조회합니다.")
-    public ResponseEntity<List<ProductResponseDto>> getAllProducts() {
-        List<ProductResponseDto> productDTOs = productService.getAllProducts();
+    public ResponseEntity<Page<ProductResponseDto>> getAllProducts(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ProductResponseDto> productDTOs = productService.getAllProducts(pageable);
         return new ResponseEntity<>(productDTOs, HttpStatus.OK);
     }
 

--- a/src/main/java/gift/controller/ProductViewController.java
+++ b/src/main/java/gift/controller/ProductViewController.java
@@ -1,11 +1,9 @@
 package gift.controller;
 
+import gift.dto.ProductPageResponseDto;
 import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.service.ProductService;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -23,8 +21,7 @@ public class ProductViewController {
     public String getAllProducts(Model model,
                                  @RequestParam(defaultValue = "0") int page,
                                  @RequestParam(defaultValue = "10") int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<ProductResponseDto> productPage = productService.getAllProducts(pageable);
+        ProductPageResponseDto productPage = productService.getAllProducts(page, size);
 
         model.addAttribute("productPage", productPage);
         model.addAttribute("currentPage", page);

--- a/src/main/java/gift/controller/ProductViewController.java
+++ b/src/main/java/gift/controller/ProductViewController.java
@@ -3,11 +3,12 @@ package gift.controller;
 import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.service.ProductService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Controller
 @RequestMapping("/products")
@@ -19,9 +20,15 @@ public class ProductViewController {
     }
 
     @GetMapping
-    public String getAllProducts(Model model) {
-        List<ProductResponseDto> products = productService.getAllProducts();
-        model.addAttribute("products", products);
+    public String getAllProducts(Model model,
+                                 @RequestParam(defaultValue = "0") int page,
+                                 @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ProductResponseDto> productPage = productService.getAllProducts(pageable);
+
+        model.addAttribute("productPage", productPage);
+        model.addAttribute("currentPage", page);
+        model.addAttribute("pageSize", size);
         return "products";
     }
 
@@ -39,15 +46,9 @@ public class ProductViewController {
 
     @GetMapping("/edit/{id}")
     public String showEditProductForm(@PathVariable Long id, Model model) {
-        ProductResponseDto product = productService.getAllProducts().stream()
-                .filter(p -> p.getId().equals(id))
-                .findFirst()
-                .orElse(null);
-        if (product != null) {
-            model.addAttribute("product", product);
-            return "product_edit_form";
-        }
-        return "redirect:/products";
+        ProductResponseDto product = productService.getProductById(id);
+        model.addAttribute("product", product);
+        return "product_edit_form";
     }
 
     @PostMapping("/edit/{id}")

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -3,11 +3,11 @@ package gift.controller;
 import gift.annotation.LoginMember;
 import gift.dto.WishRequestDto;
 import gift.dto.WishResponseDto;
+import gift.dto.WishPageResponseDto;
 import gift.entity.User;
 import gift.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,8 +32,8 @@ public class WishController {
 
     @GetMapping
     @Operation(summary = "위시리스트 조회", description = "사용자의 모든 위시리스트 항목을 조회합니다.")
-    public ResponseEntity<Page<WishResponseDto>> getWishesByUserId(@LoginMember User loginUser, Pageable pageable) {
-        Page<WishResponseDto> wishList = wishService.getWishesByUserId(loginUser.getId(), pageable);
+    public ResponseEntity<WishPageResponseDto> getWishesByUserId(@LoginMember User loginUser, Pageable pageable) {
+        WishPageResponseDto wishList = wishService.getWishesByUserId(loginUser.getId(), pageable);
         return new ResponseEntity<>(wishList, HttpStatus.OK);
     }
 

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -7,11 +7,11 @@ import gift.entity.User;
 import gift.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/wishes")
@@ -32,8 +32,8 @@ public class WishController {
 
     @GetMapping
     @Operation(summary = "위시리스트 조회", description = "사용자의 모든 위시리스트 항목을 조회합니다.")
-    public ResponseEntity<List<WishResponseDto>> getWishesByUserId(@LoginMember User loginUser) {
-        List<WishResponseDto> wishList = wishService.getWishesByUserId(loginUser.getId());
+    public ResponseEntity<Page<WishResponseDto>> getWishesByUserId(@LoginMember User loginUser, Pageable pageable) {
+        Page<WishResponseDto> wishList = wishService.getWishesByUserId(loginUser.getId(), pageable);
         return new ResponseEntity<>(wishList, HttpStatus.OK);
     }
 

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -1,7 +1,9 @@
 package gift.controller;
 
+import gift.annotation.LoginMember;
 import gift.dto.WishRequestDto;
 import gift.dto.WishResponseDto;
+import gift.entity.User;
 import gift.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,15 +25,15 @@ public class WishController {
 
     @PostMapping
     @Operation(summary = "위시리스트 추가", description = "위시리스트에 새로운 상품을 추가합니다.")
-    public ResponseEntity<WishResponseDto> addWish(@RequestHeader("userId") Long userId, @RequestBody WishRequestDto wishRequestDto) {
-        WishResponseDto createdWish = wishService.addWish(userId, wishRequestDto);
+    public ResponseEntity<WishResponseDto> addWish(@LoginMember User loginUser, @RequestBody WishRequestDto wishRequestDto) {
+        WishResponseDto createdWish = wishService.addWish(loginUser.getId(), wishRequestDto);
         return new ResponseEntity<>(createdWish, HttpStatus.CREATED);
     }
 
     @GetMapping
     @Operation(summary = "위시리스트 조회", description = "사용자의 모든 위시리스트 항목을 조회합니다.")
-    public ResponseEntity<List<WishResponseDto>> getWishesByUserId(@RequestHeader("userId") Long userId) {
-        List<WishResponseDto> wishList = wishService.getWishesByUserId(userId);
+    public ResponseEntity<List<WishResponseDto>> getWishesByUserId(@LoginMember User loginUser) {
+        List<WishResponseDto> wishList = wishService.getWishesByUserId(loginUser.getId());
         return new ResponseEntity<>(wishList, HttpStatus.OK);
     }
 

--- a/src/main/java/gift/dto/ProductPageResponseDto.java
+++ b/src/main/java/gift/dto/ProductPageResponseDto.java
@@ -1,0 +1,44 @@
+package gift.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class ProductPageResponseDto {
+    private List<ProductResponseDto> products;
+    private int currentPage;
+    private int totalPages;
+    private long totalItems;
+
+    public ProductPageResponseDto(List<ProductResponseDto> products, int currentPage, int totalPages, long totalItems) {
+        this.products = products;
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.totalItems = totalItems;
+    }
+
+    public static ProductPageResponseDto fromPage(Page<ProductResponseDto> page) {
+        return new ProductPageResponseDto(
+                page.getContent(),
+                page.getNumber(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
+
+    public List<ProductResponseDto> getProducts() {
+        return products;
+    }
+
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public long getTotalItems() {
+        return totalItems;
+    }
+}

--- a/src/main/java/gift/dto/WishPageResponseDto.java
+++ b/src/main/java/gift/dto/WishPageResponseDto.java
@@ -1,0 +1,44 @@
+package gift.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class WishPageResponseDto {
+    private List<WishResponseDto> wishes;
+    private int currentPage;
+    private int totalPages;
+    private long totalItems;
+
+    public WishPageResponseDto(List<WishResponseDto> wishes, int currentPage, int totalPages, long totalItems) {
+        this.wishes = wishes;
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.totalItems = totalItems;
+    }
+
+    public static WishPageResponseDto fromPage(Page<WishResponseDto> page) {
+        return new WishPageResponseDto(
+                page.getContent(),
+                page.getNumber(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
+
+    public List<WishResponseDto> getWishes() {
+        return wishes;
+    }
+
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public long getTotalItems() {
+        return totalItems;
+    }
+}

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -16,10 +16,10 @@ public class Product {
     @Embedded
     private ProductName name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "INT NOT NULL COMMENT 'Product Price'")
     private int price;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_url", nullable = false, columnDefinition = "VARCHAR(255) NOT NULL COMMENT 'Product Image URL'")
     private String imageUrl;
 
     protected Product() {

--- a/src/main/java/gift/entity/ProductName.java
+++ b/src/main/java/gift/entity/ProductName.java
@@ -22,7 +22,7 @@ public class ProductName {
     @NotNull(message = NULL_NAME_ERROR_MESSAGE)
     @Size(max = MAX_NAME_LENGTH, message = MAX_LENGTH_ERROR_MESSAGE)
     @Pattern(regexp = NAME_PATTERN, message = PATTERN_ERROR_MESSAGE)
-    @Column(name = "name", nullable = false, length = 15)
+    @Column(name = "name", nullable = false, length = 15, columnDefinition = "VARCHAR(255) NOT NULL COMMENT 'Product Name'")
     private String value;
 
     protected ProductName() {

--- a/src/main/java/gift/entity/User.java
+++ b/src/main/java/gift/entity/User.java
@@ -13,10 +13,10 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(255) NOT NULL COMMENT 'User Email'")
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "VARCHAR(255) NOT NULL COMMENT 'User Password'")
     private String password;
 
     protected User() {

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -10,12 +10,12 @@ public class Wish {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_user"))
     private User user;
 
-    @ManyToOne
-    @JoinColumn(name = "product_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_product"))
     private Product product;
 
     protected Wish() {

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -11,11 +11,11 @@ public class Wish {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_user"))
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_user"), columnDefinition = "BIGINT NOT NULL COMMENT 'Foreign Key to User'")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_product"))
+    @JoinColumn(name = "product_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_product"), columnDefinition = "BIGINT NOT NULL COMMENT 'Foreign Key to Product'")
     private Product product;
 
     protected Wish() {

--- a/src/main/java/gift/filter/TokenInterceptor.java
+++ b/src/main/java/gift/filter/TokenInterceptor.java
@@ -1,6 +1,7 @@
 package gift.filter;
 
 import gift.exception.BusinessException;
+import gift.exception.ErrorCode;
 import gift.service.TokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -22,7 +23,7 @@ public class TokenInterceptor implements HandlerInterceptor {
         String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), ErrorCode.UNAUTHORIZED_REQUEST.getMessage());
             return false;
         }
 
@@ -31,7 +32,7 @@ public class TokenInterceptor implements HandlerInterceptor {
         try {
             tokenService.validateToken(token);
         } catch (BusinessException e) {
-            response.setStatus(e.getErrorCode().getStatus().value());
+            response.sendError(e.getErrorCode().getStatus().value(), e.getMessage());
             return false;
         }
 

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -2,6 +2,7 @@ package gift.repository;
 
 import gift.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, PagingAndSortingRepository<Product, Long> {
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -2,10 +2,11 @@ package gift.repository;
 
 import gift.entity.User;
 import gift.entity.Wish;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
-import java.util.List;
-
-public interface WishRepository extends JpaRepository<Wish, Long> {
-    List<Wish> findByUser(User user);
+public interface WishRepository extends JpaRepository<Wish, Long>, PagingAndSortingRepository<Wish, Long> {
+    Page<Wish> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -1,5 +1,6 @@
 package gift.service;
 
+import gift.dto.ProductPageResponseDto;
 import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.entity.Product;
@@ -9,6 +10,7 @@ import gift.exception.ErrorCode;
 import gift.mapper.ProductMapper;
 import gift.repository.ProductRepository;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -38,9 +40,10 @@ public class ProductService {
         return ProductMapper.toProductResponseDTO(existingProduct);
     }
 
-    public Page<ProductResponseDto> getAllProducts(Pageable pageable) {
-        return productRepository.findAll(pageable)
-                .map(ProductMapper::toProductResponseDTO);
+    public ProductPageResponseDto getAllProducts(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ProductResponseDto> productDTOs = productRepository.findAll(pageable).map(ProductMapper::toProductResponseDTO);
+        return ProductPageResponseDto.fromPage(productDTOs);
     }
 
     public ProductResponseDto getProductById(Long id) {
@@ -62,7 +65,8 @@ public class ProductService {
     }
 
     public List<ProductResponseDto> getProductsByIds(List<Long> ids) {
-        return productRepository.findAllById(ids).stream()
+        List<Product> products = productRepository.findAllById(ids);
+        return products.stream()
                 .map(ProductMapper::toProductResponseDTO)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -8,6 +8,8 @@ import gift.exception.BusinessException;
 import gift.exception.ErrorCode;
 import gift.mapper.ProductMapper;
 import gift.repository.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -36,11 +38,9 @@ public class ProductService {
         return ProductMapper.toProductResponseDTO(existingProduct);
     }
 
-    public List<ProductResponseDto> getAllProducts() {
-        List<Product> products = productRepository.findAll();
-        return products.stream()
-                .map(ProductMapper::toProductResponseDTO)
-                .collect(Collectors.toList());
+    public Page<ProductResponseDto> getAllProducts(Pageable pageable) {
+        return productRepository.findAll(pageable)
+                .map(ProductMapper::toProductResponseDTO);
     }
 
     public ProductResponseDto getProductById(Long id) {
@@ -62,8 +62,7 @@ public class ProductService {
     }
 
     public List<ProductResponseDto> getProductsByIds(List<Long> ids) {
-        List<Product> products = productRepository.findAllById(ids);
-        return products.stream()
+        return productRepository.findAllById(ids).stream()
                 .map(ProductMapper::toProductResponseDTO)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -11,6 +11,8 @@ import gift.exception.ErrorCode;
 import gift.mapper.ProductMapper;
 import gift.mapper.WishMapper;
 import gift.repository.WishRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -38,9 +40,10 @@ public class WishService {
         return WishMapper.toWishResponseDto(createdWish, ProductMapper.toProductResponseDTO(product));
     }
 
-    public List<WishResponseDto> getWishesByUserId(Long userId) {
+    public Page<WishResponseDto> getWishesByUserId(Long userId, Pageable pageable) {
         User user = userService.getUserEntityById(userId);
-        List<Wish> wishes = wishRepository.findByUser(user);
+        Page<Wish> wishes = wishRepository.findByUser(user, pageable);
+
         List<Long> productIds = wishes.stream()
                 .map(wish -> wish.getProduct().getId())
                 .collect(Collectors.toList());
@@ -49,12 +52,10 @@ public class WishService {
         Map<Long, ProductResponseDto> productMap = products.stream()
                 .collect(Collectors.toMap(ProductResponseDto::getId, product -> product));
 
-        return wishes.stream()
-                .map(wish -> {
-                    ProductResponseDto product = productMap.get(wish.getProduct().getId());
-                    return WishMapper.toWishResponseDto(wish, product);
-                })
-                .collect(Collectors.toList());
+        return wishes.map(wish -> {
+            ProductResponseDto product = productMap.get(wish.getProduct().getId());
+            return WishMapper.toWishResponseDto(wish, product);
+        });
     }
 
     public void deleteWish(Long wishId) {

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -3,6 +3,7 @@ package gift.service;
 import gift.dto.ProductResponseDto;
 import gift.dto.WishRequestDto;
 import gift.dto.WishResponseDto;
+import gift.dto.WishPageResponseDto;
 import gift.entity.User;
 import gift.entity.Product;
 import gift.entity.Wish;
@@ -40,10 +41,9 @@ public class WishService {
         return WishMapper.toWishResponseDto(createdWish, ProductMapper.toProductResponseDTO(product));
     }
 
-    public Page<WishResponseDto> getWishesByUserId(Long userId, Pageable pageable) {
+    public WishPageResponseDto getWishesByUserId(Long userId, Pageable pageable) {
         User user = userService.getUserEntityById(userId);
         Page<Wish> wishes = wishRepository.findByUser(user, pageable);
-
         List<Long> productIds = wishes.stream()
                 .map(wish -> wish.getProduct().getId())
                 .collect(Collectors.toList());
@@ -52,10 +52,12 @@ public class WishService {
         Map<Long, ProductResponseDto> productMap = products.stream()
                 .collect(Collectors.toMap(ProductResponseDto::getId, product -> product));
 
-        return wishes.map(wish -> {
+        Page<WishResponseDto> wishResponseDtos = wishes.map(wish -> {
             ProductResponseDto product = productMap.get(wish.getProduct().getId());
             return WishMapper.toWishResponseDto(wish, product);
         });
+
+        return WishPageResponseDto.fromPage(wishResponseDtos);
     }
 
     public void deleteWish(Long wishId) {

--- a/src/main/resources/templates/products.html
+++ b/src/main/resources/templates/products.html
@@ -75,6 +75,18 @@
             text-decoration: none;
             border-radius: 4px;
         }
+        .pagination {
+            text-align: center;
+            margin-top: 20px;
+        }
+        .pagination a {
+            margin: 0 5px;
+            padding: 6px 12px;
+            text-decoration: none;
+            color: #007bff;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
     </style>
 </head>
 <body>
@@ -100,16 +112,22 @@
         <!-- 상품 목록이 여기에 동적으로 추가됩니다. -->
         </tbody>
     </table>
+    <div class="pagination" id="pagination">
+        <!-- 페이지네이션 링크가 여기에 동적으로 추가됩니다. -->
+    </div>
 </div>
 <script>
     document.addEventListener("DOMContentLoaded", function() {
-        fetch('/api/products')
-            .then(response => response.json())
-            .then(data => {
-                const productTableBody = document.getElementById("productTableBody");
-                productTableBody.innerHTML = "";
-                data.forEach(product => {
-                    productTableBody.innerHTML += `
+        loadProducts(0, 10); // 초기 페이지는 0, 페이지 크기는 10으로 설정
+
+        function loadProducts(page, size) {
+            fetch(`/api/products?page=${page}&size=${size}`)
+                .then(response => response.json())
+                .then(data => {
+                    const productTableBody = document.getElementById("productTableBody");
+                    productTableBody.innerHTML = "";
+                    data.content.forEach(product => {
+                        productTableBody.innerHTML += `
                             <tr>
                                 <td>${product.id}</td>
                                 <td>${product.name}</td>
@@ -122,21 +140,31 @@
                                     </form>
                                 </td>
                             </tr>`;
+                    });
+                    setupPagination(data);
                 });
-            });
-    });
+        }
 
-    function deleteProduct(id) {
-        fetch(`/api/products/${id}`, { method: 'DELETE' })
-            .then(response => {
-                if (response.ok) {
-                    alert('상품이 삭제되었습니다.');
-                    location.reload();
-                } else {
-                    alert('상품 삭제에 실패했습니다.');
-                }
-            });
-    }
+        function setupPagination(data) {
+            const pagination = document.getElementById("pagination");
+            pagination.innerHTML = "";
+            for (let i = 0; i < data.totalPages; i++) {
+                pagination.innerHTML += `<a href="#" onclick="loadProducts(${i}, 10); return false;">${i + 1}</a>`;
+            }
+        }
+
+        window.deleteProduct = function(id) {
+            fetch(`/api/products/${id}`, { method: 'DELETE' })
+                .then(response => {
+                    if (response.ok) {
+                        alert('상품이 삭제되었습니다.');
+                        loadProducts(0, 10); // 삭제 후 첫 페이지를 다시 로드
+                    } else {
+                        alert('상품 삭제에 실패했습니다.');
+                    }
+                });
+        }
+    });
 </script>
 </body>
 </html>

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -12,9 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 
 import static io.restassured.RestAssured.given;
@@ -44,7 +42,7 @@ public class ProductControllerTest {
     }
 
     @Test
-    public void 상품_추가() {
+    public void 상품_추가_성공() {
         ProductRequestDto productRequestDto = new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg");
 
         given()
@@ -60,7 +58,7 @@ public class ProductControllerTest {
     }
 
     @Test
-    public void 상품_수정() {
+    public void 상품_수정_성공() {
         ProductResponseDto productResponseDto = productService.addProduct(new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg"));
         Long productId = productResponseDto.getId();
 
@@ -79,30 +77,25 @@ public class ProductControllerTest {
     }
 
     @Test
-    public void 모든_상품_조회() {
+    public void 모든_상품_조회_성공() {
         ProductResponseDto productResponseDto = productService.addProduct(new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg"));
-
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ProductResponseDto> productPage = productService.getAllProducts(pageable);
 
         given()
                 .when()
                 .get("/api/products?page=0&size=10")
                 .then()
                 .statusCode(HttpStatus.OK.value())
-                .body("content[0].id", equalTo(productResponseDto.getId().intValue()))
-                .body("content[0].name", equalTo("오둥이 입니다만"))
-                .body("content[0].price", equalTo(29800))
-                .body("content[0].imageUrl", equalTo("https://example.com/product2.jpg"))
-                .body("pageable", notNullValue())
+                .body("products[0].id", equalTo(productResponseDto.getId().intValue()))
+                .body("products[0].name", equalTo("오둥이 입니다만"))
+                .body("products[0].price", equalTo(29800))
+                .body("products[0].imageUrl", equalTo("https://example.com/product2.jpg"))
+                .body("currentPage", equalTo(0))
                 .body("totalPages", equalTo(1))
-                .body("totalElements", equalTo(1))
-                .body("size", equalTo(10))
-                .body("number", equalTo(0));
+                .body("totalItems", equalTo(1));
     }
 
     @Test
-    public void 상품_삭제() {
+    public void 상품_삭제_성공() {
         ProductResponseDto productResponseDto = productService.addProduct(new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg"));
         Long productId = productResponseDto.getId();
 
@@ -111,6 +104,5 @@ public class ProductControllerTest {
                 .delete("/api/products/{id}", productId)
                 .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
-
     }
 }

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -1,0 +1,104 @@
+package gift.controller;
+
+import gift.dto.ProductRequestDto;
+import gift.dto.ProductResponseDto;
+import gift.repository.ProductRepository;
+import gift.service.ProductService;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ProductControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    @AfterEach
+    public void 데이터_삭제() {
+        productRepository.deleteAll();
+    }
+
+    @Test
+    public void 상품_추가() {
+        ProductRequestDto productRequestDto = new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg");
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(productRequestDto)
+        .when()
+            .post("/api/products")
+        .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .body("name", equalTo("오둥이 입니다만"))
+            .body("price", equalTo(29800))
+            .body("imageUrl", equalTo("https://example.com/product2.jpg"));
+    }
+
+    @Test
+    public void 상품_수정() {
+        ProductResponseDto productResponseDto = productService.addProduct(new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg"));
+        Long productId = productResponseDto.getId();
+
+        ProductRequestDto updateDTO = new ProductRequestDto("오둥이 아닙니다만", 35000, "https://example.com/product3.jpg");
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(updateDTO)
+        .when()
+            .put("/api/products/{id}", productId)
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("name", equalTo("오둥이 아닙니다만"))
+            .body("price", equalTo(35000))
+            .body("imageUrl", equalTo("https://example.com/product3.jpg"));
+    }
+
+    @Test
+    public void 모든_상품_조회() {
+        ProductResponseDto productResponseDto = productService.addProduct(new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg"));
+
+        given()
+        .when()
+            .get("/api/products")
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("[0].id", equalTo(productResponseDto.getId().intValue()))
+            .body("[0].name", equalTo("오둥이 입니다만"))
+            .body("[0].price", equalTo(29800))
+            .body("[0].imageUrl", equalTo("https://example.com/product2.jpg"));
+    }
+
+    @Test
+    public void 상품_삭제() {
+        ProductResponseDto productResponseDto = productService.addProduct(new ProductRequestDto("오둥이 입니다만", 29800, "https://example.com/product2.jpg"));
+        Long productId = productResponseDto.getId();
+
+        given()
+        .when()
+            .delete("/api/products/{id}", productId)
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT.value());
+
+    }
+}

--- a/src/test/java/gift/controller/UserControllerTest.java
+++ b/src/test/java/gift/controller/UserControllerTest.java
@@ -1,0 +1,85 @@
+package gift.controller;
+
+import gift.dto.UserLoginDto;
+import gift.dto.UserRegisterDto;
+import gift.dto.UserResponseDto;
+import gift.repository.UserRepository;
+import gift.service.UserService;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.parsing.Parser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class UserControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+        RestAssured.defaultParser = Parser.JSON;
+    }
+
+    @AfterEach
+    public void 데이터_삭제() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void 회원_가입() {
+        UserRegisterDto userRegisterDto = new UserRegisterDto("user@example.com", "password");
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(userRegisterDto)
+        .when()
+            .post("/api/users/register")
+        .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .body("email", equalTo("user@example.com"));
+    }
+
+    @Test
+    public void 모든_사용자_조회() {
+        UserRegisterDto userRegisterDto = new UserRegisterDto("user@example.com", "password");
+        userService.registerUser(userRegisterDto);
+
+        given()
+        .when()
+            .get("/api/users")
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("[0].email", equalTo("user@example.com"));
+    }
+
+    @Test
+    public void 사용자_삭제() {
+        UserRegisterDto userRegisterDto = new UserRegisterDto("user@example.com", "password");
+        UserResponseDto userResponseDto = userService.registerUser(userRegisterDto);
+        Long userId = userResponseDto.getId();
+
+        given()
+        .when()
+            .delete("/api/users/{id}", userId)
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+}

--- a/src/test/java/gift/controller/UserControllerTest.java
+++ b/src/test/java/gift/controller/UserControllerTest.java
@@ -44,7 +44,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void 회원_가입() {
+    public void 회원_가입_성공() {
         UserRegisterDto userRegisterDto = new UserRegisterDto("user@example.com", "password");
 
         given()
@@ -58,7 +58,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void 모든_사용자_조회() {
+    public void 모든_사용자_조회_성공() {
         UserRegisterDto userRegisterDto = new UserRegisterDto("user@example.com", "password");
         userService.registerUser(userRegisterDto);
 
@@ -71,7 +71,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void 사용자_삭제() {
+    public void 사용자_삭제_성공() {
         UserRegisterDto userRegisterDto = new UserRegisterDto("user@example.com", "password");
         UserResponseDto userResponseDto = userService.registerUser(userRegisterDto);
         Long userId = userResponseDto.getId();

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -17,7 +17,7 @@ public class ProductRepositoryTest {
     private ProductRepository productRepository;
 
     @Test
-    public void 상품_저장_조회() {
+    public void 상품_저장_후_조회_성공() {
         Product product = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product1.jpg");
         productRepository.save(product);
 
@@ -27,7 +27,7 @@ public class ProductRepositoryTest {
     }
 
     @Test
-    public void 상품_삭제() {
+    public void 상품_삭제_성공() {
         Product product = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product1.jpg");
         productRepository.save(product);
 

--- a/src/test/java/gift/repository/UserRepositoryTest.java
+++ b/src/test/java/gift/repository/UserRepositoryTest.java
@@ -16,7 +16,7 @@ public class UserRepositoryTest {
     private UserRepository userRepository;
 
     @Test
-    public void 사용자_저장_조회() {
+    public void 사용자_저장_조회_성공() {
         User user = new User("test@example.com", "password");
         userRepository.save(user);
 
@@ -26,7 +26,7 @@ public class UserRepositoryTest {
     }
 
     @Test
-    public void 사용자_삭제() {
+    public void 사용자_삭제_성공() {
         User user = new User("test@example.com", "password");
         userRepository.save(user);
 

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -36,7 +36,7 @@ public class WishRepositoryTest {
     }
 
     @Test
-    public void 위시리스트_저장_조회() {
+    public void 위시리스트_저장_후_조회_성공() {
         Product product = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product1.jpg");
         productRepository.save(product);
 
@@ -55,7 +55,7 @@ public class WishRepositoryTest {
     }
 
     @Test
-    public void 위시리스트_삭제() {
+    public void 위시리스트_삭제_성공() {
         Product product = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product1.jpg");
         productRepository.save(product);
 

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -4,9 +4,13 @@ import gift.entity.Product;
 import gift.entity.ProductName;
 import gift.entity.User;
 import gift.entity.Wish;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -24,6 +28,13 @@ public class WishRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
+    @AfterEach
+    public void 데이터_정리() {
+        wishRepository.deleteAll();
+        productRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
     @Test
     public void 위시리스트_저장_조회() {
         Product product = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product1.jpg");
@@ -35,7 +46,10 @@ public class WishRepositoryTest {
         Wish wish = new Wish(user, product);
         wishRepository.save(wish);
 
-        List<Wish> wishes = wishRepository.findByUser(user);
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Wish> wishesPage = wishRepository.findByUser(user, pageable);
+        List<Wish> wishes = wishesPage.getContent();
+
         assertEquals(1, wishes.size());
         assertEquals(product.getId(), wishes.get(0).getProduct().getId());
     }
@@ -53,7 +67,10 @@ public class WishRepositoryTest {
 
         wishRepository.delete(wish);
 
-        List<Wish> wishes = wishRepository.findByUser(user);
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Wish> wishesPage = wishRepository.findByUser(user, pageable);
+        List<Wish> wishes = wishesPage.getContent();
+
         assertTrue(wishes.isEmpty());
     }
 }

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -2,21 +2,17 @@ package gift.service;
 
 import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
+import gift.dto.ProductPageResponseDto;
 import gift.entity.Product;
 import gift.entity.ProductName;
 import gift.exception.BusinessException;
 import gift.repository.ProductRepository;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.annotation.Rollback;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,7 +32,7 @@ public class ProductServiceTest {
 
     @Test
     @Rollback
-    public void 상품_추가() {
+    public void 상품_추가_성공() {
         ProductRequestDto requestDTO = new ProductRequestDto("아이스 카페 아메리카노 T", 4500, "https://example.com/product1.jpg");
         ProductResponseDto createdProduct = productService.addProduct(requestDTO);
 
@@ -49,15 +45,15 @@ public class ProductServiceTest {
 
     @Test
     @Rollback
-    public void 상품_조회() {
+    public void 상품_조회_성공() {
         Product product = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product2.jpg");
         productRepository.save(product);
 
-        List<ProductResponseDto> productList = productService.getAllProducts(PageRequest.of(0, 10)).getContent();
+        ProductPageResponseDto productPage = productService.getAllProducts(0, 10);
 
-        assertNotNull(productList);
-        assertEquals(1, productList.size());
-        ProductResponseDto retrievedProduct = productList.get(0);
+        assertNotNull(productPage);
+        assertEquals(1, productPage.getTotalItems());
+        ProductResponseDto retrievedProduct = productPage.getProducts().get(0);
         assertEquals("오둥이 입니다만", retrievedProduct.getName());
         assertEquals(29800, retrievedProduct.getPrice());
         assertEquals("https://example.com/product2.jpg", retrievedProduct.getImageUrl());
@@ -65,7 +61,7 @@ public class ProductServiceTest {
 
     @Test
     @Rollback
-    public void 상품_수정() {
+    public void 상품_수정_성공() {
         Product originalProduct = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product2.jpg");
         productRepository.save(originalProduct);
 
@@ -81,7 +77,7 @@ public class ProductServiceTest {
 
     @Test
     @Rollback
-    public void 상품_수정_없는상품() {
+    public void 상품_수정_없는상품_예외_발생() {
         ProductRequestDto updateDTO = new ProductRequestDto("오둥이 아닙니다만", 35000, "https://example.com/product3.jpg");
 
         assertThrows(BusinessException.class, () -> productService.updateProduct(100L, updateDTO));
@@ -89,50 +85,47 @@ public class ProductServiceTest {
 
     @Test
     @Rollback
-    public void 상품_삭제() {
+    public void 상품_삭제_성공() {
         Product product = new Product(new ProductName("오둥이 입니다만"), 29800, "https://example.com/product2.jpg");
         productRepository.save(product);
 
         productService.deleteProduct(product.getId());
 
-        List<ProductResponseDto> productList = productService.getAllProducts(PageRequest.of(0, 10)).getContent();
-        assertTrue(productList.isEmpty());
+        ProductPageResponseDto productPage = productService.getAllProducts(0, 10);
+        assertTrue(productPage.getProducts().isEmpty());
     }
 
     @Test
     @Rollback
-    public void 상품_삭제_없는상품() {
+    public void 상품_삭제_없는상품_예외_발생() {
         assertThrows(BusinessException.class, () -> productService.deleteProduct(2L));
     }
 
     @Test
     @Rollback
-    public void 상품_목록_페이지네이션() {
+    public void 상품_목록_페이지네이션_성공() {
         for (int i = 1; i <= 25; i++) {
             Product product = new Product(new ProductName("상품 " + i), 1000 + i, "https://example.com/product" + i + ".jpg");
             productRepository.save(product);
         }
 
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ProductResponseDto> page1 = productService.getAllProducts(pageable);
+        ProductPageResponseDto page1 = productService.getAllProducts(0, 10);
 
         assertNotNull(page1);
-        assertEquals(10, page1.getNumberOfElements());
-        assertEquals(0, page1.getNumber());
+        assertEquals(10, page1.getProducts().size());
+        assertEquals(0, page1.getCurrentPage());
         assertEquals(3, page1.getTotalPages());
 
-        pageable = PageRequest.of(1, 10);
-        Page<ProductResponseDto> page2 = productService.getAllProducts(pageable);
+        ProductPageResponseDto page2 = productService.getAllProducts(1, 10);
 
         assertNotNull(page2);
-        assertEquals(10, page2.getNumberOfElements());
-        assertEquals(1, page2.getNumber());
+        assertEquals(10, page2.getProducts().size());
+        assertEquals(1, page2.getCurrentPage());
 
-        pageable = PageRequest.of(2, 10);
-        Page<ProductResponseDto> page3 = productService.getAllProducts(pageable);
+        ProductPageResponseDto page3 = productService.getAllProducts(2, 10);
 
         assertNotNull(page3);
-        assertEquals(5, page3.getNumberOfElements());
-        assertEquals(2, page3.getNumber());
+        assertEquals(5, page3.getProducts().size());
+        assertEquals(2, page3.getCurrentPage());
     }
 }

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -8,11 +8,17 @@ import gift.entity.ProductName;
 import gift.exception.BusinessException;
 import gift.repository.ProductRepository;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.annotation.Rollback;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -101,31 +107,38 @@ public class ProductServiceTest {
         assertThrows(BusinessException.class, () -> productService.deleteProduct(2L));
     }
 
-    @Test
     @Rollback
-    public void 상품_목록_페이지네이션_성공() {
+    @TestFactory
+    public Collection<DynamicTest> 상품_목록_페이지네이션_성공() {
         for (int i = 1; i <= 25; i++) {
             Product product = new Product(new ProductName("상품 " + i), 1000 + i, "https://example.com/product" + i + ".jpg");
             productRepository.save(product);
         }
 
-        ProductPageResponseDto page1 = productService.getAllProducts(0, 10);
+        List<DynamicTest> dynamicTests = new ArrayList<>();
 
-        assertNotNull(page1);
-        assertEquals(10, page1.getProducts().size());
-        assertEquals(0, page1.getCurrentPage());
-        assertEquals(3, page1.getTotalPages());
+        dynamicTests.add(DynamicTest.dynamicTest("첫번째 페이지 조회", () -> {
+            ProductPageResponseDto page1 = productService.getAllProducts(0, 10);
+            assertNotNull(page1);
+            assertEquals(10, page1.getProducts().size());
+            assertEquals(0, page1.getCurrentPage());
+            assertEquals(3, page1.getTotalPages());
+        }));
 
-        ProductPageResponseDto page2 = productService.getAllProducts(1, 10);
+        dynamicTests.add(DynamicTest.dynamicTest("두번째 페이지 조회", () -> {
+            ProductPageResponseDto page2 = productService.getAllProducts(1, 10);
+            assertNotNull(page2);
+            assertEquals(10, page2.getProducts().size());
+            assertEquals(1, page2.getCurrentPage());
+        }));
 
-        assertNotNull(page2);
-        assertEquals(10, page2.getProducts().size());
-        assertEquals(1, page2.getCurrentPage());
+        dynamicTests.add(DynamicTest.dynamicTest("세번째 페이지 조회", () -> {
+            ProductPageResponseDto page3 = productService.getAllProducts(2, 10);
+            assertNotNull(page3);
+            assertEquals(5, page3.getProducts().size());
+            assertEquals(2, page3.getCurrentPage());
+        }));
 
-        ProductPageResponseDto page3 = productService.getAllProducts(2, 10);
-
-        assertNotNull(page3);
-        assertEquals(5, page3.getProducts().size());
-        assertEquals(2, page3.getCurrentPage());
+        return dynamicTests;
     }
 }

--- a/src/test/java/gift/service/UserServiceTest.java
+++ b/src/test/java/gift/service/UserServiceTest.java
@@ -31,7 +31,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void 사용자_등록() {
+    public void 사용자_등록_성공() {
         UserRegisterDto registerDto = new UserRegisterDto("test@example.com", "password");
         UserResponseDto createdUser = userService.registerUser(registerDto);
 
@@ -41,7 +41,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void 사용자_조회() {
+    public void 사용자_조회_성공() {
         User user = new User("test@example.com", "password");
         userRepository.save(user);
 
@@ -53,7 +53,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void 사용자_수정() {
+    public void 사용자_수정_성공() {
         User originalUser = new User("test@example.com", "password");
         userRepository.save(originalUser);
 
@@ -66,7 +66,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void 사용자_삭제() {
+    public void 사용자_삭제_성공() {
         User user = new User("test@example.com", "password");
         userRepository.save(user);
 
@@ -76,7 +76,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void 로그인_성공() {
+    public void 로그인_성공_토큰_발급() {
         User user = new User("test@example.com", "password");
         userRepository.save(user);
 
@@ -87,7 +87,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void 로그인_실패() {
+    public void 잘못된_비밀번호_로그인_실패_예외_발생() {
         User user = new User("test@example.com", "password");
         userRepository.save(user);
 

--- a/src/test/java/gift/service/WishServiceTest.java
+++ b/src/test/java/gift/service/WishServiceTest.java
@@ -1,6 +1,5 @@
 package gift.service;
 
-import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.dto.WishRequestDto;
 import gift.dto.WishResponseDto;
@@ -15,10 +14,16 @@ import gift.repository.UserRepository;
 import gift.repository.WishRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.DynamicTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.annotation.Rollback;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -101,36 +106,43 @@ public class WishServiceTest {
 
     @Test
     @Rollback
-    public void 없는_위시리스트_삭제_예외_발생() {
+    public void 위시리스트_삭제_없는위시_예외_발생() {
         assertThrows(BusinessException.class, () -> wishService.deleteWish(999L));
     }
 
-    @Test
+    @TestFactory
     @Rollback
-    public void 위시리스트_목록_페이지네이션_성공() {
+    public Collection<DynamicTest> 위시리스트_목록_페이지네이션_성공() {
         User user = userRepository.save(new User("user@example.com", "password"));
         for (int i = 1; i <= 25; i++) {
             Product product = productRepository.save(new Product(new ProductName("상품 " + i), 10000, "https://example.com/product" + i + ".jpg"));
             wishRepository.save(new Wish(user, product));
         }
 
-        WishPageResponseDto wishPage = wishService.getWishesByUserId(user.getId(), PageRequest.of(0, 10));
+        List<DynamicTest> dynamicTests = new ArrayList<>();
 
-        assertNotNull(wishPage);
-        assertEquals(10, wishPage.getWishes().size());
-        assertEquals(25, wishPage.getTotalItems());
-        assertEquals(3, wishPage.getTotalPages());
+        dynamicTests.add(DynamicTest.dynamicTest("첫번째 페이지 조회", () -> {
+            WishPageResponseDto wishPage = wishService.getWishesByUserId(user.getId(), PageRequest.of(0, 10));
+            assertNotNull(wishPage);
+            assertEquals(10, wishPage.getWishes().size());
+            assertEquals(25, wishPage.getTotalItems());
+            assertEquals(3, wishPage.getTotalPages());
+        }));
 
-        WishPageResponseDto wishPage2 = wishService.getWishesByUserId(user.getId(), PageRequest.of(1, 10));
+        dynamicTests.add(DynamicTest.dynamicTest("두번째 페이지 조회", () -> {
+            WishPageResponseDto wishPage2 = wishService.getWishesByUserId(user.getId(), PageRequest.of(1, 10));
+            assertNotNull(wishPage2);
+            assertEquals(10, wishPage2.getWishes().size());
+            assertEquals(25, wishPage2.getTotalItems());
+        }));
 
-        assertNotNull(wishPage2);
-        assertEquals(10, wishPage2.getWishes().size());
-        assertEquals(25, wishPage2.getTotalItems());
+        dynamicTests.add(DynamicTest.dynamicTest("세번째 페이지 조회", () -> {
+            WishPageResponseDto wishPage3 = wishService.getWishesByUserId(user.getId(), PageRequest.of(2, 10));
+            assertNotNull(wishPage3);
+            assertEquals(5, wishPage3.getWishes().size());
+            assertEquals(25, wishPage3.getTotalItems());
+        }));
 
-        WishPageResponseDto wishPage3 = wishService.getWishesByUserId(user.getId(), PageRequest.of(2, 10));
-
-        assertNotNull(wishPage3);
-        assertEquals(5, wishPage3.getWishes().size());
-        assertEquals(25, wishPage3.getTotalItems());
+        return dynamicTests;
     }
 }


### PR DESCRIPTION
## 저번 피드백에서 JoinColumn의 fetch를 물어보셔서 그에 대해 알아보았습니다

### Fetch

연관된 엔티티를 언제 로딩할지 설정하는 속성이다. 기본값은 `FetchType.EAGER` 이며, 외에도 `LAZY` 속성이 있다.

</aside>

- `FetchType.EAGER` : **즉시 로딩**, 엔티티가 로드될 때 연관된 모든 엔티티를 즉시 로드한다. (기본값)
    
    ```java
    @ManyToOne(fetch = FetchType.EAGER) // 생략 가능
    private User user;
    ```
    
    `Wish` 엔티티가 로드될 때 `User` 엔티티도 즉시 로드된다는 의미 
    
- `FetchType.LAZY` : **지연 로딩**, 연관된 엔티티가 실제로 사용될 때까지 로드를 지연한다. 성능 최적화를 위해 사용하는 경우가 일반적임
    
    ```java
    @ManyToOne(fetch = FetchType.LAZY)
    private User user;
    ```
    
    `Wish` 엔티티가 로드될 때 `User` 엔티티는 로드되지 않고, `user` 필드에 접근할 때 로드
    

### 왜 LAZY 사용?

- **성능 최적화**
    - 실제로 필요한 시점에만 데이터를 로드하므로, 불필요한 DB 쿼리를 줄일 수 있다.
    - 필요한 데이터만 로드하므로, 전송되는 데이터의 양을 최소화할 수 있고, 메모리를 효율적으로 사용할 수 있다.
    - 필요한 데이터만 로드하므로 빠르게 응답할 수 있다. 결국 전체적인 성능 최적화를 위함임.

### 주의점

- **N + 1 문제** : 하나의 쿼리로 부모 엔티티를 로드한 후, 부모 엔티티에 대해 연관된 자식 엔티티를 로드하기 위해 추가적인 쿼리가 실행되는 문제
- `LazyInitializationException` : 지연 로딩은 실제 엔티티가 필요할 때 초기화되는 **프록시 객체**를 사용하여 연관된 엔티티를 대체하는데, 잘못된 사용으로 영속성 컨텍스트 밖에서 지연 로딩된 엔티티에 접근하려고 할 때 발생하는 `LazyInitializationException` 을 일으킬 수 있다.

그리고 직접 코드에도 적용하여 수정했습니다..! 괜찮은가요?!

---

## 페이지네이션

`PagingAndSortingRepository` 을 extends 받는 방법도 있고 

```java
public interface WishRepository extends JpaRepository<Wish, Long> {
    Page<Wish> findByUser(User user, Pageable pageable);
}
```

이렇게 구현하는 법이 있던데 뭘 사용하든 상관 없을까요? 


이번 주차는 전체적으로 개념은 어렵지만 코드를 작성할때는 그렇게 큰 어려움은 없었는데, 제가 혹시 잘못한 부분이 있어서 그런가 걱정이 되네요..ㅎㅎ 
전체적으로 한번 쓱 봐주시면 감사하겠습니다..!

늘 좋은 피드백 주셔서 감사하고 고생 많으십니다 멘토님!! 😄  