### PR TITLE
전남대 BE_김보민_3주차 과제(2단계)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@
     - ProductRepository, UserRepository, WishlistRepository
 - Repository에 대한 Test 코드 작성
   - ProductRepositoryTest, UserRepositoryTest, WishlistRepository
+---
+## 2단계 - 연관 관계 매핑
+- @ManyToOne 사용
+  - Wishlist
+- @OneToMany 사용
+  - Member
+  - Product
+  - CASCADE 사용
+- WishlistRepository 수정
+- WishlistService 수정
+- Test 코드 수정

--- a/src/main/java/gift/model/Member.java
+++ b/src/main/java/gift/model/Member.java
@@ -5,9 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 
 @Entity
 @Table(name = "member")
@@ -28,6 +30,9 @@ public class Member {
 
     @Column(name = "role")
     private String role;
+
+    @OneToMany(mappedBy = "member")
+    private List<Wishlist> wishlistList;
 
     protected Member() {
     }

--- a/src/main/java/gift/model/Member.java
+++ b/src/main/java/gift/model/Member.java
@@ -61,16 +61,53 @@ public class Member {
     }
 
     public void validate() {
-        if (name == null || name.trim().isEmpty()) {
+        validateNullName();
+        validateEmptyName();
+        validateNullEmail();
+        validateEmptyEmail();
+        validateInvalidEmail();
+        validateNullPassword();
+        validateEmptyPassword();
+    }
+
+    private void validateNullName() {
+        if (name == null) {
             throw new IllegalArgumentException("이름을 입력하세요.");
         }
-        if (email == null || email.trim().isEmpty()) {
+    }
+
+    private void validateEmptyName() {
+        if (name.trim().isEmpty()) {
+            throw new IllegalArgumentException("이름을 입력하세요.");
+        }
+    }
+
+    private void validateNullEmail() {
+        if (email == null) {
             throw new IllegalArgumentException("이메일을 입력하세요.");
         }
+    }
+
+    private void validateEmptyEmail() {
+        if (email.trim().isEmpty()) {
+            throw new IllegalArgumentException("이메일을 입력하세요.");
+        }
+    }
+
+    private void validateInvalidEmail() {
         if (!email.matches("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")) {
             throw new IllegalArgumentException("유효한 이메일을 입력하세요.");
         }
-        if (password == null || password.trim().isEmpty()) {
+    }
+
+    private void validateNullPassword() {
+        if (password == null) {
+            throw new IllegalArgumentException("비밀 번호를 입력하세요.");
+        }
+    }
+
+    private void validateEmptyPassword() {
+        if (password.trim().isEmpty()) {
             throw new IllegalArgumentException("비밀 번호를 입력하세요.");
         }
     }

--- a/src/main/java/gift/model/Member.java
+++ b/src/main/java/gift/model/Member.java
@@ -65,52 +65,36 @@ public class Member {
     }
 
     public void validate() {
-        validateNullName();
-        validateEmptyName();
-        validateNullEmail();
-        validateEmptyEmail();
-        validateInvalidEmail();
-        validateNullPassword();
-        validateEmptyPassword();
+        validateName();
+        validateEmail();
+        validatePassword();
     }
 
-    private void validateNullName() {
+    private void validateName() {
         if (name == null) {
             throw new IllegalArgumentException("이름을 입력하세요.");
         }
-    }
-
-    private void validateEmptyName() {
         if (name.trim().isEmpty()) {
             throw new IllegalArgumentException("이름을 입력하세요.");
         }
     }
 
-    private void validateNullEmail() {
+    private void validateEmail() {
         if (email == null) {
             throw new IllegalArgumentException("이메일을 입력하세요.");
         }
-    }
-
-    private void validateEmptyEmail() {
         if (email.trim().isEmpty()) {
             throw new IllegalArgumentException("이메일을 입력하세요.");
         }
-    }
-
-    private void validateInvalidEmail() {
         if (!email.matches("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")) {
             throw new IllegalArgumentException("유효한 이메일을 입력하세요.");
         }
     }
 
-    private void validateNullPassword() {
+    private void validatePassword() {
         if (password == null) {
             throw new IllegalArgumentException("비밀 번호를 입력하세요.");
         }
-    }
-
-    private void validateEmptyPassword() {
         if (password.trim().isEmpty()) {
             throw new IllegalArgumentException("비밀 번호를 입력하세요.");
         }

--- a/src/main/java/gift/model/Member.java
+++ b/src/main/java/gift/model/Member.java
@@ -1,5 +1,6 @@
 package gift.model;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,7 +32,7 @@ public class Member {
     @Column(name = "role")
     private String role;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<Wishlist> wishlistList;
 
     protected Member() {

--- a/src/main/java/gift/model/Member.java
+++ b/src/main/java/gift/model/Member.java
@@ -8,8 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 @Entity

--- a/src/main/java/gift/model/Member.java
+++ b/src/main/java/gift/model/Member.java
@@ -31,7 +31,7 @@ public class Member {
     private String role;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<Wishlist> wishlistList;
+    private List<Wishlist> wishlists;
 
     protected Member() {
     }

--- a/src/main/java/gift/model/Product.java
+++ b/src/main/java/gift/model/Product.java
@@ -1,5 +1,6 @@
 package gift.model;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -29,7 +30,7 @@ public class Product {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
-    @OneToMany(mappedBy = "product")
+    @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE)
     private List<Wishlist> wishlists;
 
     protected Product() {

--- a/src/main/java/gift/model/Product.java
+++ b/src/main/java/gift/model/Product.java
@@ -54,27 +54,80 @@ public class Product {
     }
 
     public void validate() {
-        if (name == null || name.trim().isEmpty()) {
+        validateNullName();
+        validateEmptyName();
+        validateLengthName();
+        validateInvalidName();
+        validateKaKaoName();
+        validateNullPrice();
+        validateEmptyPrice();
+        validateInvalidPrice();
+        validateNullImageUrl();
+        validateEmptyImageUrl();
+        validateInvalidImageUrl();
+    }
+
+    private void validateNullName() {
+        if (name == null) {
             throw new IllegalArgumentException("상품 이름은 최소 1자 이상이어야 합니다.");
         }
+    }
+
+    private void validateEmptyName() {
+        if (name.trim().isEmpty()) {
+            throw new IllegalArgumentException("상품 이름은 최소 1자 이상이어야 합니다.");
+        }
+    }
+
+    private void validateLengthName() {
         if (name.length() > 15) {
             throw new IllegalArgumentException("상품 이름은 공백 포함 최대 15자까지 입력할 수 있습니다.");
         }
+    }
+
+    private void validateInvalidName() {
         if (!name.matches("^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\s\\(\\)\\[\\]\\+\\-\\&\\/\\_]*$")) {
             throw new IllegalArgumentException("상품 이름에 (), [], +, -, &, /, _ 외 특수 문자는 사용할 수 없습니다.");
         }
+    }
+
+    private void validateKaKaoName() {
         if (name.contains("카카오")) {
             throw new IllegalArgumentException("'카카오'가 포함된 문구는 담당 MD와 협의 후 사용 바랍니다.");
         }
-        if (price == null || price.trim().isEmpty()) {
+    }
+
+    private void validateNullPrice() {
+        if (price == null) {
             throw new IllegalArgumentException("가격을 입력해야 합니다.");
         }
+    }
+
+    private void validateEmptyPrice() {
+        if (price.trim().isEmpty()) {
+            throw new IllegalArgumentException("가격을 입력해야 합니다.");
+        }
+    }
+
+    private void validateInvalidPrice() {
         if (!price.matches("^\\d+$")) {
             throw new IllegalArgumentException("가격은 0이상의 숫자만 입력 가능합니다.");
         }
-        if (imageUrl == null || imageUrl.trim().isEmpty()) {
+    }
+
+    private void validateNullImageUrl() {
+        if (imageUrl == null) {
             throw new IllegalArgumentException("이미지 URL을 입력해야 합니다.");
         }
+    }
+
+    private void validateEmptyImageUrl() {
+        if (imageUrl.trim().isEmpty()) {
+            throw new IllegalArgumentException("이미지 URL을 입력해야 합니다.");
+        }
+    }
+
+    private void validateInvalidImageUrl() {
         if (!imageUrl.matches("^(http|https)://.*$")) {
             throw new IllegalArgumentException("유효한 이미지 URL을 입력해야 합니다.");
         }

--- a/src/main/java/gift/model/Product.java
+++ b/src/main/java/gift/model/Product.java
@@ -8,9 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @Entity

--- a/src/main/java/gift/model/Product.java
+++ b/src/main/java/gift/model/Product.java
@@ -5,10 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 
 @Entity
 @Table(name = "product")
@@ -26,6 +28,9 @@ public class Product {
 
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
+
+    @OneToMany(mappedBy = "product")
+    private List<Wishlist> wishlists;
 
     protected Product() {
     }

--- a/src/main/java/gift/model/Product.java
+++ b/src/main/java/gift/model/Product.java
@@ -57,80 +57,48 @@ public class Product {
     }
 
     public void validate() {
-        validateNullName();
-        validateEmptyName();
-        validateLengthName();
-        validateInvalidName();
-        validateKaKaoName();
-        validateNullPrice();
-        validateEmptyPrice();
-        validateInvalidPrice();
-        validateNullImageUrl();
-        validateEmptyImageUrl();
-        validateInvalidImageUrl();
+        validateName();
+        validatePrice();
+        validateImageUrl();
     }
 
-    private void validateNullName() {
+    private void validateName() {
         if (name == null) {
             throw new IllegalArgumentException("상품 이름은 최소 1자 이상이어야 합니다.");
         }
-    }
-
-    private void validateEmptyName() {
         if (name.trim().isEmpty()) {
             throw new IllegalArgumentException("상품 이름은 최소 1자 이상이어야 합니다.");
         }
-    }
-
-    private void validateLengthName() {
         if (name.length() > 15) {
             throw new IllegalArgumentException("상품 이름은 공백 포함 최대 15자까지 입력할 수 있습니다.");
         }
-    }
-
-    private void validateInvalidName() {
         if (!name.matches("^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\s\\(\\)\\[\\]\\+\\-\\&\\/\\_]*$")) {
             throw new IllegalArgumentException("상품 이름에 (), [], +, -, &, /, _ 외 특수 문자는 사용할 수 없습니다.");
         }
-    }
-
-    private void validateKaKaoName() {
         if (name.contains("카카오")) {
             throw new IllegalArgumentException("'카카오'가 포함된 문구는 담당 MD와 협의 후 사용 바랍니다.");
         }
     }
 
-    private void validateNullPrice() {
+    private void validatePrice() {
         if (price == null) {
             throw new IllegalArgumentException("가격을 입력해야 합니다.");
         }
-    }
-
-    private void validateEmptyPrice() {
         if (price.trim().isEmpty()) {
             throw new IllegalArgumentException("가격을 입력해야 합니다.");
         }
-    }
-
-    private void validateInvalidPrice() {
         if (!price.matches("^\\d+$")) {
             throw new IllegalArgumentException("가격은 0이상의 숫자만 입력 가능합니다.");
         }
     }
 
-    private void validateNullImageUrl() {
+    private void validateImageUrl() {
         if (imageUrl == null) {
             throw new IllegalArgumentException("이미지 URL을 입력해야 합니다.");
         }
-    }
-
-    private void validateEmptyImageUrl() {
         if (imageUrl.trim().isEmpty()) {
             throw new IllegalArgumentException("이미지 URL을 입력해야 합니다.");
         }
-    }
-
-    private void validateInvalidImageUrl() {
         if (!imageUrl.matches("^(http|https)://.*$")) {
             throw new IllegalArgumentException("유효한 이미지 URL을 입력해야 합니다.");
         }

--- a/src/main/java/gift/model/Wishlist.java
+++ b/src/main/java/gift/model/Wishlist.java
@@ -1,6 +1,5 @@
 package gift.model;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/gift/model/Wishlist.java
+++ b/src/main/java/gift/model/Wishlist.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 @Entity
@@ -15,31 +17,32 @@ public class Wishlist {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "member_email", nullable = false)
-    private String memberEmail;
+    @ManyToOne
+    @JoinColumn(name = "member_email", nullable = false)
+    private Member member;
 
-    @Column(name = "product_id", nullable = false)
-    private Long productId;
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
 
     protected Wishlist() {
     }
 
-    public Wishlist(Long id, String memberEmail, Long productId) {
+    public Wishlist(Long id, Member member, Product product) {
         this.id = id;
-        this.memberEmail = memberEmail;
-        this.productId = productId;
+        this.member = member;
+        this.product = product;
     }
 
     public Long getId() {
         return id;
     }
 
-    public String getMemberEmail() {
-        return memberEmail;
+    public Member getMember() {
+        return member;
     }
 
-    public Long getProductId() {
-        return productId;
+    public Product getProduct() {
+        return product;
     }
-
 }

--- a/src/main/java/gift/repository/WishlistRepository.java
+++ b/src/main/java/gift/repository/WishlistRepository.java
@@ -12,5 +12,6 @@ import java.util.List;
 public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 
     List<Wishlist> findByMember(Member member);
+
     void deleteByMemberAndProduct(Member member, Product product);
 }

--- a/src/main/java/gift/repository/WishlistRepository.java
+++ b/src/main/java/gift/repository/WishlistRepository.java
@@ -1,5 +1,7 @@
 package gift.repository;
 
+import gift.model.Member;
+import gift.model.Product;
 import gift.model.Wishlist;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,7 +11,6 @@ import java.util.List;
 @Repository
 public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 
-    List<Wishlist> findByMemberEmail(String email);
-
-    void deleteByMemberEmailAndProductId(String email, Long productId);
+    List<Wishlist> findByMember(Member member);
+    void deleteByMemberAndProduct(Member member, Product product);
 }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -23,7 +24,6 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-    @Transactional(readOnly = true)
     public Member findMemberByEmail(String email) {
         return memberRepository.findByEmail(email);
     }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -3,8 +3,8 @@ package gift.service;
 import gift.dto.MemberDTO;
 import gift.model.Member;
 import gift.repository.MemberRepository;
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberService {
@@ -23,6 +23,7 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
+    @Transactional(readOnly = true)
     public Member findMemberByEmail(String email) {
         return memberRepository.findByEmail(email);
     }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -3,9 +3,9 @@ package gift.service;
 import gift.model.Product;
 import gift.dto.ProductDTO;
 import gift.repository.ProductRepository;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ProductService {
@@ -16,10 +16,12 @@ public class ProductService {
         this.productRepository = productRepository;
     }
 
+    @Transactional(readOnly = true)
     public List<Product> findAllProducts() {
         return productRepository.findAll();
     }
 
+    @Transactional(readOnly = true)
     public Product findProductsById(Long id) {
         return productRepository.findById(id).orElse(null);
     }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class ProductService {
 
     private final ProductRepository productRepository;
@@ -16,12 +17,10 @@ public class ProductService {
         this.productRepository = productRepository;
     }
 
-    @Transactional(readOnly = true)
     public List<Product> findAllProducts() {
         return productRepository.findAll();
     }
 
-    @Transactional(readOnly = true)
     public Product findProductsById(Long id) {
         return productRepository.findById(id).orElse(null);
     }

--- a/src/main/java/gift/service/WishlistService.java
+++ b/src/main/java/gift/service/WishlistService.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class WishlistService {
 
     private final WishlistRepository wishlistRepository;
@@ -23,7 +24,6 @@ public class WishlistService {
         this.productService = productService;
     }
 
-    @Transactional(readOnly = true)
     public List<Product> getWishlist(String email) {
         Member member = memberService.findMemberByEmail(email);
         List<Wishlist> wishlistItems = wishlistRepository.findByMember(member);

--- a/src/main/java/gift/service/WishlistService.java
+++ b/src/main/java/gift/service/WishlistService.java
@@ -7,7 +7,6 @@ import gift.repository.WishlistRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -17,7 +16,8 @@ public class WishlistService {
     private final MemberService memberService;
     private final ProductService productService;
 
-    public WishlistService(WishlistRepository wishlistRepository, MemberService memberService, ProductService productService) {
+    public WishlistService(WishlistRepository wishlistRepository, MemberService memberService,
+        ProductService productService) {
         this.wishlistRepository = wishlistRepository;
         this.memberService = memberService;
         this.productService = productService;

--- a/src/main/java/gift/service/WishlistService.java
+++ b/src/main/java/gift/service/WishlistService.java
@@ -3,11 +3,11 @@ package gift.service;
 import gift.model.Product;
 import gift.model.Wishlist;
 import gift.repository.WishlistRepository;
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class WishlistService {
@@ -20,6 +20,7 @@ public class WishlistService {
         this.productService = productService;
     }
 
+    @Transactional(readOnly = true)
     public List<Product> getWishlist(String email) {
         List<Wishlist> wishlistItems = wishlistRepository.findByMemberEmail(email);
         return wishlistItems.stream()

--- a/src/main/java/gift/service/WishlistService.java
+++ b/src/main/java/gift/service/WishlistService.java
@@ -1,5 +1,6 @@
 package gift.service;
 
+import gift.model.Member;
 import gift.model.Product;
 import gift.model.Wishlist;
 import gift.repository.WishlistRepository;
@@ -13,29 +14,36 @@ import org.springframework.transaction.annotation.Transactional;
 public class WishlistService {
 
     private final WishlistRepository wishlistRepository;
+    private final MemberService memberService;
     private final ProductService productService;
 
-    public WishlistService(WishlistRepository wishlistRepository, ProductService productService) {
+    public WishlistService(WishlistRepository wishlistRepository, MemberService memberService, ProductService productService) {
         this.wishlistRepository = wishlistRepository;
+        this.memberService = memberService;
         this.productService = productService;
     }
 
     @Transactional(readOnly = true)
     public List<Product> getWishlist(String email) {
-        List<Wishlist> wishlistItems = wishlistRepository.findByMemberEmail(email);
+        Member member = memberService.findMemberByEmail(email);
+        List<Wishlist> wishlistItems = wishlistRepository.findByMember(member);
         return wishlistItems.stream()
-            .map(item -> productService.findProductsById(item.getProductId()))
-            .collect(Collectors.toList());
+            .map(Wishlist::getProduct)
+            .toList();
     }
 
     @Transactional
     public void addWishlist(String email, Long productId) {
-        Wishlist wishlist = new Wishlist(null, email, productId);
+        Member member = memberService.findMemberByEmail(email);
+        Product product = productService.findProductsById(productId);
+        Wishlist wishlist = new Wishlist(null, member, product);
         wishlistRepository.save(wishlist);
     }
 
     @Transactional
     public void removeWishlist(String email, Long productId) {
-        wishlistRepository.deleteByMemberEmailAndProductId(email, productId);
+        Member member = memberService.findMemberByEmail(email);
+        Product product = productService.findProductsById(productId);
+        wishlistRepository.deleteByMemberAndProduct(member, product);
     }
 }

--- a/src/test/java/gift/repository/MemberRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberRepositoryTest.java
@@ -12,19 +12,15 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 @DataJpaTest
 class MemberRepositoryTest {
 
+    @Autowired
     private MemberRepository memberRepository;
 
     private Member member;
     private Member invalidMember;
 
-    @Autowired
-    public MemberRepositoryTest(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
-
     @BeforeEach
     public void setUp() {
-        member = new Member(1L, "kbm", "kbm@kbm", "mbk", "user");
+        member = new Member(1L, "kbm", "kbm@kbm.com", "mbk", "user");
     }
 
 

--- a/src/test/java/gift/repository/MemberRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberRepositoryTest.java
@@ -16,11 +16,24 @@ class MemberRepositoryTest {
     private MemberRepository memberRepository;
 
     private Member member;
-    private Member invalidMember;
+    private Member nullNameMember;
+    private Member emptyNameMember;
+    private Member nullEmailMember;
+    private Member emptyEmailMember;
+    private Member invalidEmailMember;
+    private Member nullPasswordMember;
+    private Member emptyPasswordMember;
 
     @BeforeEach
     public void setUp() {
         member = new Member(1L, "kbm", "kbm@kbm.com", "mbk", "user");
+        nullNameMember = new Member(1L, null, "kbm@kbm.com", "mbk", "user");
+        emptyNameMember = new Member(1L, "", "kbm@kbm.com", "mbk", "user");
+        nullEmailMember = new Member(1L, "kbm", null, "mbk", "user");
+        emptyEmailMember = new Member(1L, "kbm", "", "mbk", "user");
+        invalidEmailMember = new Member(1L, "kbm", "kbm", "mbk", "user");
+        nullPasswordMember = new Member(1L, "kbm", "kbm@kbm.com", null, "user");
+        emptyPasswordMember = new Member(1L, "kbm", "kbm@kbm.com", "", "user");
     }
 
 
@@ -51,9 +64,18 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithNullName() {
         try {
-            invalidMember = new Member(1L, null, "kbm@kbm", "mbk", "user");
-            invalidMember.validate();
-            memberRepository.save(invalidMember);
+            nullNameMember.validate();
+            memberRepository.save(nullNameMember);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void testSaveWithEmptyName() {
+        try {
+            emptyNameMember.validate();
+            memberRepository.save(emptyNameMember);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
@@ -62,20 +84,28 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithNullEmail() {
         try {
-            invalidMember = new Member(1L, "kbm", null, "mbk", "user");
-            invalidMember.validate();
-            memberRepository.save(invalidMember);
+            nullEmailMember.validate();
+            memberRepository.save(nullEmailMember);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
     @Test
-    void testSaveWithInvalidEmail() {
+    void testSaveWithEmptyEmail() {
         try {
-            invalidMember = new Member(1L, "kbm", "invalid", "mbk", "user");
-            invalidMember.validate();
-            memberRepository.save(invalidMember);
+            emptyEmailMember.validate();
+            memberRepository.save(emptyEmailMember);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void testSaveWithInvalidName() {
+        try {
+            invalidEmailMember.validate();
+            memberRepository.save(invalidEmailMember);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
@@ -84,9 +114,18 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithNullPassword() {
         try {
-            invalidMember = new Member(1L, "kbm", "kbm@kbm", null, "user");
-            invalidMember.validate();
-            memberRepository.save(invalidMember);
+            nullPasswordMember.validate();
+            memberRepository.save(nullPasswordMember);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void testSaveWithEmptyPassword() {
+        try {
+            emptyPasswordMember.validate();
+            memberRepository.save(emptyPasswordMember);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }

--- a/src/test/java/gift/repository/MemberRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberRepositoryTest.java
@@ -16,31 +16,18 @@ class MemberRepositoryTest {
     private MemberRepository memberRepository;
 
     private Member member;
-    private Member nullNameMember;
-    private Member emptyNameMember;
-    private Member nullEmailMember;
-    private Member emptyEmailMember;
-    private Member invalidEmailMember;
-    private Member nullPasswordMember;
-    private Member emptyPasswordMember;
+    private Member savedMember;
 
     @BeforeEach
     public void setUp() {
         member = new Member(1L, "kbm", "kbm@kbm.com", "mbk", "user");
-        nullNameMember = new Member(1L, null, "kbm@kbm.com", "mbk", "user");
-        emptyNameMember = new Member(1L, "", "kbm@kbm.com", "mbk", "user");
-        nullEmailMember = new Member(1L, "kbm", null, "mbk", "user");
-        emptyEmailMember = new Member(1L, "kbm", "", "mbk", "user");
-        invalidEmailMember = new Member(1L, "kbm", "kbm", "mbk", "user");
-        nullPasswordMember = new Member(1L, "kbm", "kbm@kbm.com", null, "user");
-        emptyPasswordMember = new Member(1L, "kbm", "kbm@kbm.com", "", "user");
+        savedMember = memberRepository.save(member);
     }
 
 
     @Test
     void testSave() {
         member.validate();
-        Member savedMember = memberRepository.save(member);
         assertAll(
             () -> assertThat(savedMember.getId()).isNotNull(),
             () -> assertThat(savedMember.getName()).isEqualTo(member.getName()),
@@ -53,7 +40,6 @@ class MemberRepositoryTest {
     @Test
     void testFindByEmail() {
         member.validate();
-        Member savedMember = memberRepository.save(member);
         Member foundMember = memberRepository.findByEmail(member.getEmail());
         assertAll(
             () -> assertThat(foundMember).isNotNull(),
@@ -64,6 +50,7 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithNullName() {
         try {
+            Member nullNameMember = new Member(1L, null, "kbm@kbm.com", "mbk", "user");
             nullNameMember.validate();
             memberRepository.save(nullNameMember);
         } catch (IllegalArgumentException e) {
@@ -74,6 +61,7 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithEmptyName() {
         try {
+            Member emptyNameMember = new Member(1L, "", "kbm@kbm.com", "mbk", "user");
             emptyNameMember.validate();
             memberRepository.save(emptyNameMember);
         } catch (IllegalArgumentException e) {
@@ -84,6 +72,7 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithNullEmail() {
         try {
+            Member nullEmailMember = new Member(1L, "kbm", null, "mbk", "user");
             nullEmailMember.validate();
             memberRepository.save(nullEmailMember);
         } catch (IllegalArgumentException e) {
@@ -94,6 +83,7 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithEmptyEmail() {
         try {
+            Member emptyEmailMember = new Member(1L, "kbm", "", "mbk", "user");
             emptyEmailMember.validate();
             memberRepository.save(emptyEmailMember);
         } catch (IllegalArgumentException e) {
@@ -104,6 +94,7 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithInvalidName() {
         try {
+            Member invalidEmailMember = new Member(1L, "kbm", "kbm", "mbk", "user");
             invalidEmailMember.validate();
             memberRepository.save(invalidEmailMember);
         } catch (IllegalArgumentException e) {
@@ -114,6 +105,7 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithNullPassword() {
         try {
+            Member nullPasswordMember = new Member(1L, "kbm", "kbm@kbm.com", null, "user");
             nullPasswordMember.validate();
             memberRepository.save(nullPasswordMember);
         } catch (IllegalArgumentException e) {
@@ -124,6 +116,7 @@ class MemberRepositoryTest {
     @Test
     void testSaveWithEmptyPassword() {
         try {
+            Member emptyPasswordMember = new Member(1L, "kbm", "kbm@kbm.com", "", "user");
             emptyPasswordMember.validate();
             memberRepository.save(emptyPasswordMember);
         } catch (IllegalArgumentException e) {

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -18,39 +18,19 @@ class ProductRepositoryTest {
 
     private Product product1;
     private Product product2;
-    private Product nullNameProduct;
-    private Product emptyNameProduct;
-    private Product lengthNameProduct;
-    private Product invalidNameProduct;
-    private Product kakaoNameProduct;
-    private Product nullPriceProduct;
-    private Product emptyPriceProduct;
-    private Product invalidPriceProduct;
-    private Product nullImageUrlProduct;
-    private Product emptyImageUrlProduct;
-    private Product invalidImageUrlProduct;
+    private Product savedProduct;
 
     @BeforeEach
     public void setUp() {
         product1 = new Product(1L, "상품", "100", "https://kakao");
         product2 = new Product(2L, "상품2", "200", "https://kakao2");
-        nullNameProduct = new Product(1L, null,"100", "https://kakao");
-        emptyNameProduct = new Product(1L, "", "200", "https://kakao");
-        lengthNameProduct = new Product(1L, "aaaa aaaa aaaa a", "200", "https://kakao");
-        invalidNameProduct = new Product(1L, ".", "100", "https://kakao");
-        kakaoNameProduct = new Product(1L, "카카오", "100", "https://kakao");
-        nullPriceProduct = new Product(1L, "상품",null, "https://kakao");
-        emptyPriceProduct = new Product(1L, "상품", "", "https://kakao");
-        invalidPriceProduct = new Product(1L, "상품", "abcde", "https://kakao");
-        nullImageUrlProduct = new Product(1L, "상품", "100", null);
-        emptyImageUrlProduct = new Product(1L, "상품", "100", "");
-        invalidImageUrlProduct = new Product(1L, "상품", "100", "kbm");
+        savedProduct = productRepository.save(product1);
+        productRepository.save(product2);
     }
 
     @Test
     void testSave() {
         product1.validate();
-        Product savedProduct = productRepository.save(product1);
         assertAll(
             () -> assertThat(savedProduct.getId()).isNotNull(),
             () -> assertThat(savedProduct.getName()).isEqualTo(product1.getName()),
@@ -63,8 +43,6 @@ class ProductRepositoryTest {
     void testFindAll() {
         product1.validate();
         product2.validate();
-        productRepository.save(product1);
-        productRepository.save(product2);
         List<Product> products = productRepository.findAll();
         assertAll(
             () -> assertThat(products.size()).isEqualTo(2),
@@ -76,7 +54,6 @@ class ProductRepositoryTest {
     @Test
     void testFindById() {
         product1.validate();
-        Product savedProduct = productRepository.save(product1);
         assertAll(
             () -> assertThat(savedProduct).isNotNull(),
             () -> assertThat(savedProduct.getId()).isEqualTo(product1.getId())
@@ -86,7 +63,6 @@ class ProductRepositoryTest {
     @Test
     void testDelete() {
         product1.validate();
-        Product savedProduct = productRepository.save(product1);
         productRepository.deleteById(savedProduct.getId());
         boolean exists = productRepository.existsById(savedProduct.getId());
         assertThat(exists).isFalse();
@@ -95,6 +71,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithNullName() {
         try {
+            Product nullNameProduct = new Product(1L, null, "100", "https://kakao");
             nullNameProduct.validate();
             productRepository.save(nullNameProduct);
         } catch (IllegalArgumentException e) {
@@ -105,6 +82,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithEmptyName() {
         try {
+            Product emptyNameProduct = new Product(1L, "", "200", "https://kakao");
             emptyNameProduct.validate();
             productRepository.save(emptyNameProduct);
         } catch (IllegalArgumentException e) {
@@ -115,6 +93,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithLengthName() {
         try {
+            Product lengthNameProduct = new Product(1L, "aaaa aaaa aaaa a", "200", "https://kakao");
             lengthNameProduct.validate();
             productRepository.save(lengthNameProduct);
         } catch (IllegalArgumentException e) {
@@ -125,6 +104,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithInvalidName() {
         try {
+            Product invalidNameProduct = new Product(1L, ".", "100", "https://kakao");
             invalidNameProduct.validate();
             productRepository.save(invalidNameProduct);
         } catch (IllegalArgumentException e) {
@@ -135,6 +115,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithKaKaoName() {
         try {
+            Product kakaoNameProduct = new Product(1L, "카카오", "100", "https://kakao");
             kakaoNameProduct.validate();
             productRepository.save(kakaoNameProduct);
         } catch (IllegalArgumentException e) {
@@ -146,6 +127,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithNullPrice() {
         try {
+            Product nullPriceProduct = new Product(1L, "상품",null, "https://kakao");
             nullPriceProduct.validate();
             productRepository.save(nullPriceProduct);
         } catch (IllegalArgumentException e) {
@@ -156,6 +138,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithEmptyPrice() {
         try {
+            Product emptyPriceProduct = new Product(1L, "상품", "", "https://kakao");
             emptyPriceProduct.validate();
             productRepository.save(emptyPriceProduct);
         } catch (IllegalArgumentException e) {
@@ -167,6 +150,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithInvalidPrice() {
         try {
+            Product invalidPriceProduct = new Product(1L, "상품", "abcde", "https://kakao");
             invalidPriceProduct.validate();
             productRepository.save(invalidPriceProduct);
         } catch (IllegalArgumentException e) {
@@ -177,6 +161,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithNullImageUrl() {
         try {
+            Product nullImageUrlProduct = new Product(1L, "상품", "100", null);
             nullImageUrlProduct.validate();
             productRepository.save(nullImageUrlProduct);
         } catch (IllegalArgumentException e) {
@@ -187,6 +172,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithEmptyImageUrl() {
         try {
+            Product emptyImageUrlProduct = new Product(1L, "상품", "100", "");
             emptyImageUrlProduct.validate();
             productRepository.save(emptyImageUrlProduct);
         } catch (IllegalArgumentException e) {
@@ -197,6 +183,7 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithInvalidImageUrl() {
         try {
+            Product invalidImageUrlProduct = new Product(1L, "상품", "100", "kbm");
             invalidImageUrlProduct.validate();
             productRepository.save(invalidImageUrlProduct);
         } catch (IllegalArgumentException e) {

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -13,16 +13,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 @DataJpaTest
 class ProductRepositoryTest {
 
+    @Autowired
     private ProductRepository productRepository;
 
     private Product product1;
     private Product product2;
     private Product invalidProduct;
-
-    @Autowired
-    public ProductRepositoryTest(ProductRepository productRepository) {
-        this.productRepository = productRepository;
-    }
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -18,12 +18,33 @@ class ProductRepositoryTest {
 
     private Product product1;
     private Product product2;
-    private Product invalidProduct;
+    private Product nullNameProduct;
+    private Product emptyNameProduct;
+    private Product lengthNameProduct;
+    private Product invalidNameProduct;
+    private Product kakaoNameProduct;
+    private Product nullPriceProduct;
+    private Product emptyPriceProduct;
+    private Product invalidPriceProduct;
+    private Product nullImageUrlProduct;
+    private Product emptyImageUrlProduct;
+    private Product invalidImageUrlProduct;
 
     @BeforeEach
     public void setUp() {
         product1 = new Product(1L, "상품", "100", "https://kakao");
         product2 = new Product(2L, "상품2", "200", "https://kakao2");
+        nullNameProduct = new Product(1L, null,"100", "https://kakao");
+        emptyNameProduct = new Product(1L, "", "200", "https://kakao");
+        lengthNameProduct = new Product(1L, "aaaa aaaa aaaa a", "200", "https://kakao");
+        invalidNameProduct = new Product(1L, ".", "100", "https://kakao");
+        kakaoNameProduct = new Product(1L, "카카오", "100", "https://kakao");
+        nullPriceProduct = new Product(1L, "상품",null, "https://kakao");
+        emptyPriceProduct = new Product(1L, "상품", "", "https://kakao");
+        invalidPriceProduct = new Product(1L, "상품", "abcde", "https://kakao");
+        nullImageUrlProduct = new Product(1L, "상품", "100", null);
+        emptyImageUrlProduct = new Product(1L, "상품", "100", "");
+        invalidImageUrlProduct = new Product(1L, "상품", "100", "kbm");
     }
 
     @Test
@@ -74,9 +95,18 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithNullName() {
         try {
-            invalidProduct = new Product(1L, null, "100", "https://kakao");
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            nullNameProduct.validate();
+            productRepository.save(nullNameProduct);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void testSaveWithEmptyName() {
+        try {
+            emptyNameProduct.validate();
+            productRepository.save(emptyNameProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
@@ -85,20 +115,18 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithLengthName() {
         try {
-            invalidProduct = new Product(1L, "aaaaaaaaa aaaa aa", "100", "https://kakao");
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            lengthNameProduct.validate();
+            productRepository.save(lengthNameProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
     @Test
-    void testSaveWithSpecial() {
+    void testSaveWithInvalidName() {
         try {
-            invalidProduct = new Product(1L, ".@", "100", "https://kakao");
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            invalidNameProduct.validate();
+            productRepository.save(invalidNameProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
@@ -107,31 +135,40 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithKaKaoName() {
         try {
-            invalidProduct = new Product(1L, "카카오상품", "100", "https://kakao");
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            kakaoNameProduct.validate();
+            productRepository.save(kakaoNameProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
+
 
     @Test
     void testSaveWithNullPrice() {
         try {
-            invalidProduct = new Product(1L, "상품", null, "https://kakao");
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            nullPriceProduct.validate();
+            productRepository.save(nullPriceProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
     @Test
+    void testSaveWithEmptyPrice() {
+        try {
+            emptyPriceProduct.validate();
+            productRepository.save(emptyPriceProduct);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+
+    @Test
     void testSaveWithInvalidPrice() {
         try {
-            invalidProduct = new Product(1L, "상품", "가격", "https://kakao");
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            invalidPriceProduct.validate();
+            productRepository.save(invalidPriceProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
@@ -140,9 +177,18 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithNullImageUrl() {
         try {
-            invalidProduct = new Product(1L, "상품", "100", null);
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            nullImageUrlProduct.validate();
+            productRepository.save(nullImageUrlProduct);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void testSaveWithEmptyImageUrl() {
+        try {
+            emptyImageUrlProduct.validate();
+            productRepository.save(emptyImageUrlProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
@@ -151,9 +197,8 @@ class ProductRepositoryTest {
     @Test
     void testSaveWithInvalidImageUrl() {
         try {
-            Product invalidProduct = new Product(1L, "상품", "100", "kakao");
-            invalidProduct.validate();
-            productRepository.save(invalidProduct);
+            invalidImageUrlProduct.validate();
+            productRepository.save(invalidImageUrlProduct);
         } catch (IllegalArgumentException e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }

--- a/src/test/java/gift/repository/WishlistRepositoryTest.java
+++ b/src/test/java/gift/repository/WishlistRepositoryTest.java
@@ -37,7 +37,7 @@ class WishlistRepositoryTest {
         savedMember = memberRepository.save(member);
         Product product = new Product(1L, "상품", "100", "https://kakao");
         savedProduct = productRepository.save(product);
-        savedWishlist = new Wishlist(1L, savedMember.getEmail(), savedProduct.getId());
+        savedWishlist = new Wishlist(1L, savedMember, savedProduct);
     }
 
     @Test
@@ -45,27 +45,26 @@ class WishlistRepositoryTest {
         Wishlist saved = wishlistRepository.save(savedWishlist);
         assertAll(
             () -> assertThat(saved.getId()).isNotNull(),
-            () -> assertThat(saved.getMemberEmail()).isEqualTo("kbm@kbm"),
-            () -> assertThat(saved.getProductId()).isEqualTo(1L)
+            () -> assertThat(saved.getMember().getEmail()).isEqualTo("kbm@kbm"),
+            () -> assertThat(saved.getProduct().getId()).isEqualTo(1L)
         );
     }
 
     @Test
     public void testFindByMemberEmail() {
         wishlistRepository.save(savedWishlist);
-        List<Wishlist> found = wishlistRepository.findByMemberEmail(savedMember.getEmail());
+        List<Wishlist> found = wishlistRepository.findByMember(savedMember);
         assertAll(
             () -> assertThat(found.size()).isEqualTo(1),
-            () -> assertThat(found.get(0).getMemberEmail()).isEqualTo(savedMember.getEmail())
+            () -> assertThat(found.get(0).getMember().getEmail()).isEqualTo(savedMember.getEmail())
         );
     }
 
     @Test
     void testDeleteByMemberEmailAndProductId() {
         wishlistRepository.save(savedWishlist);
-        wishlistRepository.deleteByMemberEmailAndProductId(savedMember.getEmail(),
-            savedProduct.getId());
-        List<Wishlist> result = wishlistRepository.findByMemberEmail(savedMember.getEmail());
+        wishlistRepository.deleteByMemberAndProduct(savedMember, savedProduct);
+        List<Wishlist> result = wishlistRepository.findByMember(savedMember);
         assertThat(result.size()).isEqualTo(0);
     }
 }

--- a/src/test/java/gift/repository/WishlistRepositoryTest.java
+++ b/src/test/java/gift/repository/WishlistRepositoryTest.java
@@ -29,6 +29,7 @@ class WishlistRepositoryTest {
 
     private Member savedMember;
     private Product savedProduct;
+    private Wishlist savedWishlist;
 
     @BeforeEach
     public void setUp() {
@@ -36,15 +37,12 @@ class WishlistRepositoryTest {
         savedMember = memberRepository.save(member);
         Product product = new Product(1L, "상품", "100", "https://kakao");
         savedProduct = productRepository.save(product);
+        savedWishlist = new Wishlist(1L, savedMember.getEmail(), savedProduct.getId());
     }
 
     @Test
     public void testSaveWishlist() {
-
-        Wishlist wishlist = new Wishlist(1L, savedMember.getEmail(), savedProduct.getId());
-
-        Wishlist saved = wishlistRepository.save(wishlist);
-
+        Wishlist saved = wishlistRepository.save(savedWishlist);
         assertAll(
             () -> assertThat(saved.getId()).isNotNull(),
             () -> assertThat(saved.getMemberEmail()).isEqualTo("kbm@kbm"),
@@ -54,8 +52,7 @@ class WishlistRepositoryTest {
 
     @Test
     public void testFindByMemberEmail() {
-        Wishlist wishlist = new Wishlist(1L, savedMember.getEmail(), savedProduct.getId());
-        wishlistRepository.save(wishlist);
+        wishlistRepository.save(savedWishlist);
         List<Wishlist> found = wishlistRepository.findByMemberEmail(savedMember.getEmail());
         assertAll(
             () -> assertThat(found.size()).isEqualTo(1),
@@ -65,8 +62,7 @@ class WishlistRepositoryTest {
 
     @Test
     void testDeleteByMemberEmailAndProductId() {
-        Wishlist wishlist = new Wishlist(1L, savedMember.getEmail(), savedProduct.getId());
-        wishlistRepository.save(wishlist);
+        wishlistRepository.save(savedWishlist);
         wishlistRepository.deleteByMemberEmailAndProductId(savedMember.getEmail(),
             savedProduct.getId());
         List<Wishlist> result = wishlistRepository.findByMemberEmail(savedMember.getEmail());

--- a/src/test/java/gift/repository/WishlistRepositoryTest.java
+++ b/src/test/java/gift/repository/WishlistRepositoryTest.java
@@ -18,20 +18,17 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 @DataJpaTest
 class WishlistRepositoryTest {
 
+    @Autowired
     private WishlistRepository wishlistRepository;
+
+    @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
     private ProductRepository productRepository;
 
     private Member savedMember;
     private Product savedProduct;
-
-    @Autowired
-    public WishlistRepositoryTest(WishlistRepository wishlistRepository,
-        MemberRepository memberRepository, ProductRepository productRepository) {
-        this.wishlistRepository = wishlistRepository;
-        this.memberRepository = memberRepository;
-        this.productRepository = productRepository;
-    }
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
### 1단계 리뷰 수정
1. 기본 생성자를 private로 해도 되는가?
   - JPA가 매핑한 Entity를 조회할 때 hibernate가 생성한 proxy 객체를 사용하여 연관된 데이터를 실제 사용하는 시점에서 조회 가능합니다. proxy 객체는 직접 만든 객체 class를 상속하기 때문에 private로 기본 생성자를 선언하면 파생 클래스로부터의 상속 형태가 접근 불가가 되어버립니다. 그래서 private로 선언하면 안된다고 생각합니다.
2. 조회 쿼리의 `@Transactional`
   - 조회 쿼리에는 성능 최적화와 안정성을 위해서 `@Transactional(readOnly=true)`를 사용할 수 있습니다. 데이터 일관성을 위해 삭제, 추가, 업데이트에만 붙이는 것인 줄 알았는데 readOnly라는 옵션을 새로 알게 되었습니다. 감사합니다!
3. `@BeforeEach` 관련 질문
   - `private Product invalidProduct;` 로 선언하고 각 테스트마다 `invalidProduct = new Product(...)`를 사용해 테스트별로 다른 예외가 발생하도록 작성했었습니다. 수정한 것은 예외가 발생할 수 있는 객체들을 `@BeforeEach`에 작성해 두었습니다. 이 객체들은 각 테스트 코드에서 한 번만 수행되는데 이렇게 작성하게 되면 코드가 길어지는 것 아닌가 라는 생각이 들었습니다. 
# 2단계
### 코드 작성하면서 어려웠던 점
상품 목록에 있는 상품을 위시 리스트에 추가한 뒤 상품 목록에서 삭제를 해버리면 에러가 발생했습니다. 이를 해결하고자 찾은 것이 CASCADE입니다. cascade의 타입 중 remove를 사용해서 해결은 했습니다. cascade와 함께 '고아 객체', 'orphanRemoval'도 찾게 되었습니다. 이 둘의 관계가 아직 무엇인지 잘 모르겠습니다...
일대다, 다대일 개념이 처음에 헷갈려서 반대로 작성을 했었습니다. 하지만 강의 자료를 보고 검색도 하며 수정을 했습니다.

### 중점적으로 봐주셨으면 하는 점
검증 메소드를 분리했는데 이렇게 분리하는 것인지 봐주셨으면 합니다. 테스트 코드도 잘 작성되었는지 봐주셨으면 합니다. 추가로 관계 매핑이 잘 되었는지도 봐주셨으면 합니다.